### PR TITLE
Version 4.0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿### 4.0.1.0 (2019-11-25)
+﻿### 4.0.1.1 (2019-11-25)
+  * Fixed an issue where an older version of AWSSDK.SageMakerRuntime was included in the modules resulting in the MSI installer being non functional.
+
+### 4.0.1.0 (2019-11-25)
   * AWS Tools for PowerShell now use AWS .NET SDK 3.3.637.0 and leverage its new features and improvements. Please find a description of the changes at https://github.com/aws/aws-sdk-net/blob/master/SDK.CHANGELOG.md.
   * Fixed Get-AWSCmdletName returning wrong cmdlet names.
   * Fixed error in AWS.Tools.Installer.

--- a/Include/sdk/_sdk-versions.json
+++ b/Include/sdk/_sdk-versions.json
@@ -929,7 +929,7 @@
             "InPreview"               : false
         },
         "SageMakerRuntime"                : {
-            "Version" : "3.3.100.4",
+            "Version" : "3.3.100.99",
             "AssemblyVersionOverride" : null,
             "Dependencies"            : {
                 "Core" : "3.3.103.68"


### PR DESCRIPTION
Fixed an issue where an older version of AWSSDK.SageMakerRuntime was included in the modules resulting in the MSI installer being non functional.

- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-tools-for-powershell/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement