### PR TITLE
Add Install-AWSToolsModule -Name validation & tab expansion

### DIFF
--- a/modules/Installer/AWS.Tools.Installer.psm1
+++ b/modules/Installer/AWS.Tools.Installer.psm1
@@ -586,10 +586,6 @@ function Install-AWSToolsModule {
             throw "The Name parameter must contain only AWS.Tools modules without duplicates."
         }
 
-        if ($Name -eq 'AWS.Tools.Installer') {
-            throw "AWS.Tools.Installer cannot be used to install AWS.Tools.Installer. Use Update-Module instead."
-        }
-        
         if ($RequiredVersion) {
             $versionToInstall = $RequiredVersion
         }


### PR DESCRIPTION
For the `AWS.Tools.Installer` module's `Install-AWSToolsModule` cmdlet's `Name` parameter, adds validation, tab expansion, and a more specific error message on invalid values.

## Description
<!--- Describe your changes in detail -->
* Add custom arguments attribute validation class for dynamic population
  of AWS.Tools module names
* Add argument completer for tab completion of valid values
  * Minimum PowerShell version supported for the module is v5.1, so did not implement pre-v5.0 methods like in `AWS.Tools.Common.Completers`.
* Add module parameters for users that require a proxy for querying the PowerShell Gallery
  * Example:
    ```powershell
    Import-Module -Name 'AWS.Tools.Installer' -ArgumentList 'http://proxy', $credentials
    ```
* Add module variable for module name: `$script:AWSToolsInstallerModuleName = 'AWS.Tools.Installer'`
* Remove test for module name = 'AWS.Tools.Installer' since this is now covered by parameter validation

## Motivation and Context
Improving user experience.
Closes #72 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Imported my working `AWS.Tools.Installer.psm1`, and tested tab completion for 1 & 2 module names with first 0, 2, & 10 characters, and then installed each successfully.
* Entered invalid module names and expected error received
* Entered arrays of mixed valid & invalid module names and expected error received
```powershell
PS C:\> Install-AWSToolsModule -Name ApiGatewayManagementApi, ApplicationAutoScalin
Install-AWSToolsModule : Cannot validate argument on parameter 'Name'. The argument "ApplicationAutoScalin" does not
belong to the set "ACMPCA, AlexaForBusiness, Amplify, APIGateway, ApiGatewayManagementApi, ApiGatewayV2,
ApplicationAutoScaling, ApplicationDiscoveryService, ApplicationInsights, AppMesh, AppStream, AppSync, Athena,
AutoScaling, AutoScalingPlans, AWSHealth, AWSMarketplaceCommerceAnalytics, AWSMarketplaceMetering, AWSSupport, Backup,
Batch, Budgets, CertificateManager, Chime, Cloud9, CloudDirectory, CloudFormation, CloudFront, CloudHSMV2,
CloudSearch, CloudSearchDomain, CloudTrail, CloudWatch, CloudWatchLogs, CodeBuild, CodeCommit, CodeDeploy,
CodePipeline, CodeStar, CodeStarNotifications, CognitoIdentity, CognitoIdentityProvider, CognitoSync, Common,
Comprehend, ComprehendMedical, ConfigService, Connect, ConnectParticipant, CostAndUsageReport, CostExplorer,
DatabaseMigrationService, DataExchange, DataPipeline, DataSync, DAX, DeviceFarm, DirectConnect, DirectoryService, DLM,
DocDB, DynamoDBv2, EC2, ECR, ECS, EKS, ElastiCache, ElasticBeanstalk, ElasticFileSystem, ElasticLoadBalancing,
ElasticLoadBalancingV2, ElasticMapReduce, Elasticsearch, ElasticTranscoder, EventBridge, FMS, ForecastQueryService,
ForecastService, FSx, GameLift, Glacier, GlobalAccelerator, Glue, Greengrass, GroundStation, GuardDuty,
IdentityManagement, ImportExport, Inspector, IoT, IoTEvents, IoTEventsData, IoTJobsDataPlane, IoTThingsGraph, Kafka,
KeyManagementService, Kinesis, KinesisAnalyticsV2, KinesisFirehose, KinesisVideo, KinesisVideoMedia, LakeFormation,
Lambda, Lex, LexModelBuildingService, LicenseManager, Lightsail, Macie, ManagedBlockchain, MarketplaceCatalog,
MarketplaceEntitlementService, MediaConnect, MediaConvert, MediaLive, MediaPackage, MediaPackageVod, MediaStore,
MediaStoreData, MediaTailor, MigrationHub, MigrationHubConfig, Mobile, MQ, MTurk, Neptune, OpsWorks, OpsWorksCM,
Organizations, Personalize, PersonalizeEvents, PersonalizeRuntime, PI, Pinpoint, PinpointEmail, Polly, Pricing, QLDB,
QLDBSession, QuickSight, RAM, RDS, RDSDataService, Redshift, Rekognition, ResourceGroups, ResourceGroupsTaggingAPI,
RoboMaker, Route53, Route53Domains, Route53Resolver, S3, S3Control, SageMaker, SageMakerRuntime, SavingsPlans,
SecretsManager, SecurityHub, SecurityToken, ServerlessApplicationRepository, ServerMigrationService, ServiceCatalog,
ServiceDiscovery, ServiceQuotas, Shield, SimpleEmail, SimpleEmailV2, SimpleNotificationService,
SimpleSystemsManagement, SimpleWorkflow, Snowball, SQS, SSO, SSOOIDC, StepFunctions, StorageGateway, Textract,
TranscribeService, Transfer, Translate, WAF, WAFRegional, WorkDocs, WorkLink, WorkMail, WorkMailMessageFlow,
WorkSpaces, XRay, AWS.Tools.ACMPCA, AWS.Tools.AlexaForBusiness, AWS.Tools.Amplify, AWS.Tools.APIGateway,
AWS.Tools.ApiGatewayManagementApi, AWS.Tools.ApiGatewayV2, AWS.Tools.ApplicationAutoScaling,
AWS.Tools.ApplicationDiscoveryService, AWS.Tools.ApplicationInsights, AWS.Tools.AppMesh, AWS.Tools.AppStream,
AWS.Tools.AppSync, AWS.Tools.Athena, AWS.Tools.AutoScaling, AWS.Tools.AutoScalingPlans, AWS.Tools.AWSHealth,
AWS.Tools.AWSMarketplaceCommerceAnalytics, AWS.Tools.AWSMarketplaceMetering, AWS.Tools.AWSSupport, AWS.Tools.Backup,
AWS.Tools.Batch, AWS.Tools.Budgets, AWS.Tools.CertificateManager, AWS.Tools.Chime, AWS.Tools.Cloud9,
AWS.Tools.CloudDirectory, AWS.Tools.CloudFormation, AWS.Tools.CloudFront, AWS.Tools.CloudHSMV2, AWS.Tools.CloudSearch,
AWS.Tools.CloudSearchDomain, AWS.Tools.CloudTrail, AWS.Tools.CloudWatch, AWS.Tools.CloudWatchLogs,
AWS.Tools.CodeBuild, AWS.Tools.CodeCommit, AWS.Tools.CodeDeploy, AWS.Tools.CodePipeline, AWS.Tools.CodeStar,
AWS.Tools.CodeStarNotifications, AWS.Tools.CognitoIdentity, AWS.Tools.CognitoIdentityProvider, AWS.Tools.CognitoSync,
AWS.Tools.Common, AWS.Tools.Comprehend, AWS.Tools.ComprehendMedical, AWS.Tools.ConfigService, AWS.Tools.Connect,
AWS.Tools.ConnectParticipant, AWS.Tools.CostAndUsageReport, AWS.Tools.CostExplorer,
AWS.Tools.DatabaseMigrationService, AWS.Tools.DataExchange, AWS.Tools.DataPipeline, AWS.Tools.DataSync, AWS.Tools.DAX,
AWS.Tools.DeviceFarm, AWS.Tools.DirectConnect, AWS.Tools.DirectoryService, AWS.Tools.DLM, AWS.Tools.DocDB,
AWS.Tools.DynamoDBv2, AWS.Tools.EC2, AWS.Tools.ECR, AWS.Tools.ECS, AWS.Tools.EKS, AWS.Tools.ElastiCache,
AWS.Tools.ElasticBeanstalk, AWS.Tools.ElasticFileSystem, AWS.Tools.ElasticLoadBalancing,
AWS.Tools.ElasticLoadBalancingV2, AWS.Tools.ElasticMapReduce, AWS.Tools.Elasticsearch, AWS.Tools.ElasticTranscoder,
AWS.Tools.EventBridge, AWS.Tools.FMS, AWS.Tools.ForecastQueryService, AWS.Tools.ForecastService, AWS.Tools.FSx,
AWS.Tools.GameLift, AWS.Tools.Glacier, AWS.Tools.GlobalAccelerator, AWS.Tools.Glue, AWS.Tools.Greengrass,
AWS.Tools.GroundStation, AWS.Tools.GuardDuty, AWS.Tools.IdentityManagement, AWS.Tools.ImportExport,
AWS.Tools.Inspector, AWS.Tools.IoT, AWS.Tools.IoTEvents, AWS.Tools.IoTEventsData, AWS.Tools.IoTJobsDataPlane,
AWS.Tools.IoTThingsGraph, AWS.Tools.Kafka, AWS.Tools.KeyManagementService, AWS.Tools.Kinesis,
AWS.Tools.KinesisAnalyticsV2, AWS.Tools.KinesisFirehose, AWS.Tools.KinesisVideo, AWS.Tools.KinesisVideoMedia,
AWS.Tools.LakeFormation, AWS.Tools.Lambda, AWS.Tools.Lex, AWS.Tools.LexModelBuildingService, AWS.Tools.LicenseManager,
AWS.Tools.Lightsail, AWS.Tools.Macie, AWS.Tools.ManagedBlockchain, AWS.Tools.MarketplaceCatalog,
AWS.Tools.MarketplaceEntitlementService, AWS.Tools.MediaConnect, AWS.Tools.MediaConvert, AWS.Tools.MediaLive,
AWS.Tools.MediaPackage, AWS.Tools.MediaPackageVod, AWS.Tools.MediaStore, AWS.Tools.MediaStoreData,
AWS.Tools.MediaTailor, AWS.Tools.MigrationHub, AWS.Tools.MigrationHubConfig, AWS.Tools.Mobile, AWS.Tools.MQ,
AWS.Tools.MTurk, AWS.Tools.Neptune, AWS.Tools.OpsWorks, AWS.Tools.OpsWorksCM, AWS.Tools.Organizations,
AWS.Tools.Personalize, AWS.Tools.PersonalizeEvents, AWS.Tools.PersonalizeRuntime, AWS.Tools.PI, AWS.Tools.Pinpoint,
AWS.Tools.PinpointEmail, AWS.Tools.Polly, AWS.Tools.Pricing, AWS.Tools.QLDB, AWS.Tools.QLDBSession,
AWS.Tools.QuickSight, AWS.Tools.RAM, AWS.Tools.RDS, AWS.Tools.RDSDataService, AWS.Tools.Redshift,
AWS.Tools.Rekognition, AWS.Tools.ResourceGroups, AWS.Tools.ResourceGroupsTaggingAPI, AWS.Tools.RoboMaker,
AWS.Tools.Route53, AWS.Tools.Route53Domains, AWS.Tools.Route53Resolver, AWS.Tools.S3, AWS.Tools.S3Control,
AWS.Tools.SageMaker, AWS.Tools.SageMakerRuntime, AWS.Tools.SavingsPlans, AWS.Tools.SecretsManager,
AWS.Tools.SecurityHub, AWS.Tools.SecurityToken, AWS.Tools.ServerlessApplicationRepository,
AWS.Tools.ServerMigrationService, AWS.Tools.ServiceCatalog, AWS.Tools.ServiceDiscovery, AWS.Tools.ServiceQuotas,
AWS.Tools.Shield, AWS.Tools.SimpleEmail, AWS.Tools.SimpleEmailV2, AWS.Tools.SimpleNotificationService,
AWS.Tools.SimpleSystemsManagement, AWS.Tools.SimpleWorkflow, AWS.Tools.Snowball, AWS.Tools.SQS, AWS.Tools.SSO,
AWS.Tools.SSOOIDC, AWS.Tools.StepFunctions, AWS.Tools.StorageGateway, AWS.Tools.Textract, AWS.Tools.TranscribeService,
AWS.Tools.Transfer, AWS.Tools.Translate, AWS.Tools.WAF, AWS.Tools.WAFRegional, AWS.Tools.WorkDocs, AWS.Tools.WorkLink,
AWS.Tools.WorkMail, AWS.Tools.WorkMailMessageFlow, AWS.Tools.WorkSpaces, AWS.Tools.XRay" specified by the
ValidateAwsToolsModuleSet attribute. Supply an argument that is in the set and then try the command again.
At line:1 char:30
+ ... l-AWSToolsModule -Name ApiGatewayManagementApi, ApplicationAutoScalin
+                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Install-AWSToolsModule], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationError,Install-AWSToolsModule
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-tools-for-powershell/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement