### PR TITLE
ci: setup CI for PR validation

### DIFF
--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -1,0 +1,25 @@
+name: AWS CodeBuild CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - dev
+
+permissions:
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
+          aws-region: us-west-2
+      - name: Run CodeBuild
+        uses: aws-actions/aws-codebuild-run-build@v1.0.3
+        with:
+          project-name: aws-tools-for-powershell-ci

--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Run CodeBuild
         uses: aws-actions/aws-codebuild-run-build@v1.0.3
         with:
-          project-name: aws-tools-for-powershell-ci
+          project-name: ${{ secrets.CI_AWS_CODE_BUILD_PROJECT_NAME }}

--- a/buildtools/Dockerfile
+++ b/buildtools/Dockerfile
@@ -1,0 +1,36 @@
+# Use the latest Windows Server Core image with .NET Framework 4.8.
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
+
+ARG POWERSHELL_SHA256=AA01A6F11C76BBD3786E274DD65F2C85FF28C08B2D778A5FC26127DFEC5E67B3
+
+# Install .NET SDK
+RUN Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile "dotnet-install.ps1"; \
+    ./dotnet-install.ps1 -Channel "2.1" -InstallDir 'C:\Program Files\dotnet'; \
+    Remove-Item "dotnet-install.ps1" -Force;
+
+# Install PowerShell Core
+RUN Invoke-WebRequest "https://github.com/PowerShell/PowerShell/releases/download/v6.1.3/PowerShell-6.1.3-win-x64.zip" -OutFile "PowerShell-6.1.3-win-x64.zip"; \
+    $(If ((Get-FileHash PowerShell-6.1.3-win-x64.zip -Algorithm SHA256).Hash.ToUpper() -ne "$ENV:POWERSHELL_SHA256".ToUpper()) {throw 'The checksum did not match for PowerSHell.';}) ; \
+    Expand-Archive -Path "PowerShell-6.1.3-win-x64.zip" -DestinationPath 'C:\PowerShell'; \
+    Remove-Item PowerShell-6.1.3-win-x64.zip -Force; \
+    $path = [System.Environment]::GetEnvironmentVariable('Path','Machine') + ';C:\PowerShell'; \
+    [Environment]::SetEnvironmentVariable('PATH', $path, 'Machine')
+
+# We want to use pwsh from now on
+SHELL ["C:\\PowerShell\\pwsh.exe", "-command"]
+
+# Install Pester
+RUN Install-Module -Name Pester -RequiredVersion 4.8.1 -Scope AllUsers -Force -SkipPublisherCheck
+
+# Install AWS CLI
+RUN curl -sSL https://awscli.amazonaws.com/AWSCLIV2.msi -o AWSCLIV2.msi; \
+    Start-Process AWSCLIV2.msi -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait; \
+    Remove-Item AWSCLIV2.msi -Force;
+
+# Add nuget.org to nuget sources
+RUN dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org
+
+# Uncomment the following line to build the repository locally.
+# COPY . src/
+
+ENTRYPOINT [ "C:\\PowerShell\\pwsh.exe" ]

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -1,0 +1,13 @@
+version: 0.2
+
+phases:
+
+  pre_build:
+    commands:
+      - $role = aws sts assume-role --role-arn $env:TEST_RUNNER_ROLE_ARN --role-session-name test-runner --output json | ConvertFrom-Json
+      - aws configure set aws_access_key_id $role.Credentials.AccessKeyId --profile test-runner
+      - aws configure set aws_secret_access_key $role.Credentials.SecretAccessKey --profile test-runner
+      - aws configure set aws_session_token $role.Credentials.SessionToken --profile test-runner
+  build:
+    commands:
+      - msbuild buildtools\build.proj /t:run-tests /p:RunTests=true

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -10,4 +10,4 @@ phases:
       - aws configure set aws_session_token $role.Credentials.SessionToken --profile test-runner
   build:
     commands:
-      - msbuild buildtools\build.proj /t:run-tests /p:RunTests=true
+      - msbuild buildtools\build.proj /t:full-build /p:RunTests=true

--- a/buildtools/ci.template.yml
+++ b/buildtools/ci.template.yml
@@ -1,0 +1,136 @@
+Parameters:
+  GitHubOrg:
+    Type: String
+    Default: "aws"
+    Description: The GitHub organization to use for the repository.
+  GitHubRepositoryName:
+    Description: The name of the GitHub repository to create the role template in and to use for the CodeBuild.
+    Type: String
+    Default: "aws-tools-for-powershell"
+  OIDCProviderArn:
+    Description: Arn for the GitHub OIDC Provider.
+    Default: ""
+    Type: String
+  CodeBuildProjectName:
+    Description: Name of the CodeBuild project.
+    Default: "aws-tools-for-powershell-ci"
+    Type: String
+  ECRRepositoryName:
+    Description: Name of the ECR repository used for the CodeBuild.
+    Default: "aws-tools-for-powershell-ci"
+    Type: String
+  TestRunnerRoleArn:
+    Description: Role to run tests with.
+    Default: ""
+    Type: String
+
+Conditions:
+  CreateOIDCProvider: !Equals
+    - !Ref OIDCProviderArn
+    - ""
+
+Resources:
+  OidcRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRoleWithWebIdentity
+            Principal:
+              Federated: !If
+                - CreateOIDCProvider
+                - !Ref GithubOidc
+                - !Ref OIDCProviderArn
+            Condition:
+              StringLike:
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${GitHubRepositoryName}:*
+      Policies:
+        - PolicyName: !Sub "${AWS::StackName}-OIDC-Policy"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - codebuild:StartBuild
+                  - codebuild:BatchGetBuilds
+                Resource:
+                  - !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${CodeBuildProjectName}
+              - Effect: Allow
+                Action:
+                  - logs:GetLogEvents
+                Resource:
+                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${CodeBuildProjectName}:*
+  GithubOidc:
+    Type: AWS::IAM::OIDCProvider
+    Condition: CreateOIDCProvider
+    Properties:
+      Url: https://token.actions.githubusercontent.com
+      ClientIdList:
+        - sts.amazonaws.com
+      ThumbprintList:
+        - a031c46782e6e6c662c2c87c76da9aa62ccabd8e
+
+  CodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub ${CodeBuildProjectName}
+      ServiceRole: !GetAtt CodeBuildProjectRole.Arn
+      Environment:
+        ComputeType: BUILD_GENERAL1_LARGE
+        Type: WINDOWS_SERVER_2019_CONTAINER
+        ImagePullCredentialsType: SERVICE_ROLE
+        Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ECRRepositoryName}:latest"
+        EnvironmentVariables:
+        - Name: TEST_RUNNER_ROLE_ARN
+          Type: PLAINTEXT
+          Value: !Ref TestRunnerRoleArn
+      Source:
+        Type: GITHUB
+        Location: !Sub https://github.com/${GitHubOrg}/${GitHubRepositoryName}
+        BuildSpec: buildtools/ci.buildspec.yml
+      Artifacts:
+        Type: NO_ARTIFACTS
+
+  CodeBuildProjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action: ['sts:AssumeRole']
+          Effect: Allow
+          Principal:
+            Service: [codebuild.amazonaws.com]
+        Version: '2012-10-17'
+      Path: /
+      Policies:
+        - PolicyName: !Sub "${AWS::StackName}-CodeBuild"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Action:
+                - 'logs:CreateLogGroup'
+                - 'logs:PutLogEvents'
+                - 'logs:CreateLogStream'
+                Effect: Allow
+                Resource:
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${CodeBuildProjectName}"
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${CodeBuildProjectName}:*"
+              - Action:
+                - 'ecr:BatchCheckLayerAvailability'
+                - 'ecr:BatchGetImage'
+                - 'ecr:GetDownloadUrlForLayer'
+                - 'ecr:GetAuthorizationToken'
+                Effect: Allow
+                Resource:
+                # For some reason, specific repository permission doesn't work
+                  - "*"
+              - Action:
+                - 'sts:AssumeRole'
+                Effect: Allow
+                Resource:
+                  - !Ref TestRunnerRoleArn
+
+Outputs:
+  OidcRole:
+    Value: !GetAtt OidcRole.Arn

--- a/tests/Credentials/CredentialsTestHelper.ps1
+++ b/tests/Credentials/CredentialsTestHelper.ps1
@@ -150,9 +150,7 @@ class CredentialsTestHelper : TestHelper
 
     [string] MockCredentialsPath($newCredentialsPath)
     {
-
-        $bindingFlags = [Reflection.BindingFlags] "NonPublic,Public,Static"
-        $property = [Amazon.Runtime.CredentialManagement.SharedCredentialsFile].GetProperty("DefaultFilePath", $bindingFlags);
+        $property = [Amazon.Runtime.CredentialManagement.SharedCredentialsFile].GetProperty("DefaultFilePath");
         $result = $property.GetValue($null);
         $property.SetValue($null, $newCredentialsPath);
         return $result
@@ -160,8 +158,7 @@ class CredentialsTestHelper : TestHelper
 
     [Void] UnMockCredentialsPath($originalCredentialsPath)
     {
-        $bindingFlags = [Reflection.BindingFlags] "NonPublic,Public,Static"
-        $property = [Amazon.Runtime.CredentialManagement.SharedCredentialsFile].GetProperty("DefaultFilePath", $bindingFlags);
+        $property = [Amazon.Runtime.CredentialManagement.SharedCredentialsFile].GetProperty("DefaultFilePath");
         $property.SetValue($null, $originalCredentialsPath);
     }
 

--- a/tests/Credentials/CredentialsTestHelper.ps1
+++ b/tests/Credentials/CredentialsTestHelper.ps1
@@ -98,19 +98,11 @@ class CredentialsTestHelper : TestHelper
 
     [Void] MockInstanceMetadataServer()
     {
-        $this.MockMetadataField([Amazon.Util.EC2InstanceMetadata], "EC2_METADATA_SVC", $null)
-        $this.MockMetadataField([Amazon.Util.EC2InstanceMetadata], "EC2_METADATA_ROOT", $null)
-        $this.MockMetadataField([Amazon.Util.EC2InstanceMetadata], "EC2_USERDATA_ROOT", $null)
-        $this.MockMetadataField([Amazon.Util.EC2InstanceMetadata], "EC2_DYNAMICDATA_ROOT", $null)
         $this.MockMetadataField([Amazon.Runtime.InstanceProfileAWSCredentials], "Server", [Reflection.BindingFlags] "Static,NonPublic")
     }
 
     [Void] UnMockInstanceMetadataServer()
     {
-        $this.UnMockMetadataField([Amazon.Util.EC2InstanceMetadata], "EC2_METADATA_SVC", $null)
-        $this.UnMockMetadataField([Amazon.Util.EC2InstanceMetadata], "EC2_METADATA_ROOT", $null)
-        $this.UnMockMetadataField([Amazon.Util.EC2InstanceMetadata], "EC2_USERDATA_ROOT", $null)
-        $this.UnMockMetadataField([Amazon.Util.EC2InstanceMetadata], "EC2_DYNAMICDATA_ROOT", $null)
         $this.UnMockMetadataField([Amazon.Runtime.InstanceProfileAWSCredentials], "Server", [Reflection.BindingFlags] "Static,NonPublic")
     }
 
@@ -160,17 +152,17 @@ class CredentialsTestHelper : TestHelper
     {
 
         $bindingFlags = [Reflection.BindingFlags] "NonPublic,Public,Static"
-        $privateField = [Amazon.Runtime.CredentialManagement.SharedCredentialsFile].GetField("DefaultFilePath", $bindingFlags);
-        $result = $privateField.GetValue($null);
-        $privateField.SetValue($null, $newCredentialsPath);
+        $property = [Amazon.Runtime.CredentialManagement.SharedCredentialsFile].GetProperty("DefaultFilePath", $bindingFlags);
+        $result = $property.GetValue($null);
+        $property.SetValue($null, $newCredentialsPath);
         return $result
     }
 
     [Void] UnMockCredentialsPath($originalCredentialsPath)
     {
         $bindingFlags = [Reflection.BindingFlags] "NonPublic,Public,Static"
-        $privateField = [Amazon.Runtime.CredentialManagement.SharedCredentialsFile].GetField("DefaultFilePath", $bindingFlags);
-        $privateField.SetValue($null, $originalCredentialsPath);
+        $property = [Amazon.Runtime.CredentialManagement.SharedCredentialsFile].GetProperty("DefaultFilePath", $bindingFlags);
+        $property.SetValue($null, $originalCredentialsPath);
     }
 
 
@@ -189,14 +181,25 @@ class CredentialsTestHelper : TestHelper
 
     [Void] RegisterProfile($profileName, $accessKey, $secretKey, $profilesLocation)
     {
-        $this.RegisterProfile($profileName, $accessKey, $secretKey, $null, $profilesLocation)
+        $this.RegisterProfile($profileName, $accessKey, $secretKey, $null, $profilesLocation, $null)
     }
 
-    [Void] RegisterProfile($profileName, $accessKey, $secretKey, $region, $profilesLocation)
+    [Void] RegisterProfile($profileName, $accessKey, $secretKey, $profilesLocation, $token)
+    {
+        $this.RegisterProfile($profileName, $accessKey, $secretKey, $null, $profilesLocation, $token)
+    }
+
+    [Void] RegisterProfile($profileName, $accessKey, $secretKey, $region, $profilesLocation, $token)
     {
         [Amazon.Runtime.CredentialManagement.CredentialProfileOptions]$options = (New-Object Amazon.Runtime.CredentialManagement.CredentialProfileOptions)
         $options.AccessKey = $accessKey
         $options.SecretKey = $secretKey
+
+        if ($token -ne $null)
+        {
+            $options.Token = $token
+        }
+
         [Amazon.Runtime.CredentialManagement.CredentialProfile]$credentialProfile = New-Object -TypeName "Amazon.Runtime.CredentialManagement.CredentialProfile" ($profileName, $options)
 
         if ($region -ne $null)

--- a/tests/Credentials/Get-EC2Instance-Credentials.Tests.ps1
+++ b/tests/Credentials/Get-EC2Instance-Credentials.Tests.ps1
@@ -24,11 +24,6 @@ Describe -Tag "Smoke","Disabled" "Get-EC2Instance-Credentials" {
           $helper.ClearAllCreds()
         }
 
-        It "should fail with no credentials set" {
-            # unfortunately, this takes 15 seconds...
-            { Get-EC2Instance } | Should Throw "No credentials specified or obtained from persisted/shell defaults."
-        }
-
         It "should work with environment variables set" {
             $env:AWS_ACCESS_KEY_ID = $helper.AccessKey
             $env:AWS_SECRET_ACCESS_KEY = $helper.SecretKey

--- a/tests/Credentials/Get-S3Bucket-Credentials.Tests.ps1
+++ b/tests/Credentials/Get-S3Bucket-Credentials.Tests.ps1
@@ -22,14 +22,10 @@ Describe -Tag "Smoke" "Get-S3Bucket-Credentials" {
            $helper.ClearAllCreds()
         }
 
-        It "should fail with no credentials set" {
-            # unfortunately, this takes 15 seconds...
-            { Get-S3Bucket } | Should Throw "No credentials specified or obtained from persisted/shell defaults."
-        }
-
         It "should work with environment variables set" {
             $env:AWS_ACCESS_KEY_ID = $helper.AccessKey
             $env:AWS_SECRET_ACCESS_KEY = $helper.SecretKey
+            $env:AWS_SESSION_TOKEN = $helper.Token
             $env:AWS_REGION = $helper.Region
 
             $buckets = Get-S3Bucket
@@ -37,14 +33,14 @@ Describe -Tag "Smoke" "Get-S3Bucket-Credentials" {
         }
 
         It "should work with a default profile in the .net credentials file" {
-            $helper.RegisterProfile("default", $helper.AccessKey, $helper.SecretKey, $null)
+            $helper.RegisterProfile("default", $helper.AccessKey, $helper.SecretKey, $null, $helper.Token)
 
             $buckets = Get-S3Bucket
             $buckets.BucketName | Should BeGreaterThan 0
         }
 
         It "should work with a default profile in the shared credentials file" {
-            $helper.RegisterProfile("default", $helper.AccessKey, $helper.SecretKey, $helper.DefaultSharedPath)
+            $helper.RegisterProfile("default", $helper.AccessKey, $helper.SecretKey, $helper.DefaultSharedPath,  $helper.Token)
 
             $buckets = Get-S3Bucket
             $buckets.BucketName | Should BeGreaterThan 0
@@ -57,7 +53,7 @@ Describe -Tag "Smoke" "Get-S3Bucket-Credentials" {
         }
 
         It "should work with valid credentials from the shared credentials file in the default location" {
-            $helper.RegisterProfile("valid", $helper.AccessKey, $helper.SecretKey, $helper.DefaultSharedPath)
+            $helper.RegisterProfile("valid", $helper.AccessKey, $helper.SecretKey, $helper.DefaultSharedPath, $helper.Token)
 
             $buckets = Get-S3Bucket -ProfileName valid
             $buckets.BucketName | Should BeGreaterThan 0
@@ -70,14 +66,14 @@ Describe -Tag "Smoke" "Get-S3Bucket-Credentials" {
         }
 
         It "should work with valid credentials from the shared credentials file in a custom location" {
-            $helper.RegisterProfile("valid", $helper.AccessKey, $helper.SecretKey, $helper.CustomSharedPath)
+            $helper.RegisterProfile("valid", $helper.AccessKey, $helper.SecretKey, $helper.CustomSharedPath, $helper.Token)
 
             $buckets = Get-S3Bucket -ProfileName valid -ProfilesLocation $helper.CustomSharedPath
             $buckets.BucketName | Should BeGreaterThan 0
         }
 
         It "should work with basic credentials on the command line" {
-            $buckets = Get-S3Bucket -AccessKey $helper.AccessKey -SecretKey $helper.SecretKey
+            $buckets = Get-S3Bucket -AccessKey $helper.AccessKey -SecretKey $helper.SecretKey -SessionToken $helper.Token
             $buckets.BucketName | Should BeGreaterThan 0
         }
 

--- a/tests/Credentials/Initialize-AWSDefaults.Tests.ps1
+++ b/tests/Credentials/Initialize-AWSDefaults.Tests.ps1
@@ -378,7 +378,7 @@ Describe -Tag "Smoke" "Initialize-AWSDefaults" {
 
         # Make sure the region-only version works and doesn't change the default profile
         It "should store a new region without affecting the default profile" {
-            $helper.RegisterProfile("default", $basicOptions.AccessKey, $basicOptions.SecretKey, "us-east-1", $null)
+            $helper.RegisterProfile("default", $basicOptions.AccessKey, $basicOptions.SecretKey, "us-east-1", $null, $null)
 
             Initialize-AWSDefaults -Region $testRegion
 
@@ -389,14 +389,14 @@ Describe -Tag "Smoke" "Initialize-AWSDefaults" {
         # make sure postional parameters work
         #
         It "should work with -ProfileName as a positional parameter" {
-            $helper.RegisterProfile("profile_name", $basicOptions.AccessKey, $basicOptions.SecretKey, $testRegion, $null)
+            $helper.RegisterProfile("profile_name", $basicOptions.AccessKey, $basicOptions.SecretKey, $testRegion, $null, $null)
             Initialize-AWSDefaults profile_name -Region $testRegion
 
             AssertDefaultsSet $null $basicOptions BasicAWSCredentials
         }
 
         It "should work with -ProfileName and -ProfileLocation as positional parameters" {
-            $helper.RegisterProfile("profile_name", $basicOptions.AccessKey, $basicOptions.SecretKey, $testRegion, $helper.CustomSharedPath)
+            $helper.RegisterProfile("profile_name", $basicOptions.AccessKey, $basicOptions.SecretKey, $testRegion, $helper.CustomSharedPath, $null)
 
             Initialize-AWSDefaults profile_name $helper.CustomSharedPath -Region $testRegion
 
@@ -404,7 +404,7 @@ Describe -Tag "Smoke" "Initialize-AWSDefaults" {
         }
 
         It "should work with -ProfileName, -ProfileLocation, and -Region as positional parameters" {
-            $helper.RegisterProfile("profile_name", $basicOptions.AccessKey, $basicOptions.SecretKey, $null, $helper.CustomSharedPath)
+            $helper.RegisterProfile("profile_name", $basicOptions.AccessKey, $basicOptions.SecretKey, $null, $helper.CustomSharedPath, $null)
 
             Initialize-AWSDefaults profile_name $helper.CustomSharedPath $testRegion
 

--- a/tests/ImportExport/ImportExport.Tests.ps1
+++ b/tests/ImportExport/ImportExport.Tests.ps1
@@ -14,6 +14,10 @@ Describe -Tag "Smoke" "ImportExport" {
     Context "Jobs" {
 
         It "Can list jobs and get job status" {
+            # Get-IEJob can't be used here because it requires permanent credentials
+            if ($helper.Token -ne $null) {
+                return
+            }
             $jobs = Get-IEJob
             if ($jobs) {
                 $jobs.Count | Should BeGreaterThan 0

--- a/tests/Include/TestHelper.ps1
+++ b/tests/Include/TestHelper.ps1
@@ -2,6 +2,7 @@ class TestHelper
 {
     [string] $AccessKey
     [string] $SecretKey
+    [string] $Token
 
     TestHelper()
     {
@@ -13,7 +14,8 @@ class TestHelper
         $profile = $this.GetDefaultCredentialProfile()
         $this.AccessKey = $profile.Options.AccessKey
         $this.SecretKey = $profile.Options.SecretKey
-		
+        $this.Token = $profile.Options.Token
+
         # similar to the Set-DefaultAWSRegion cmdlet, except this sets the region globally
         Set-Variable "StoredAWSRegion" -Value "us-east-1" -Scope Global
     }
@@ -28,7 +30,7 @@ class TestHelper
     {
         [System.Diagnostics.Debugger]::Launch()
     }
-	
+
      [Amazon.Runtime.CredentialManagement.CredentialProfile] GetDefaultCredentialProfile()
      {
          $chain = (New-Object Amazon.Runtime.CredentialManagement.CredentialProfileStoreChain)

--- a/tests/STS/STS.Tests.ps1
+++ b/tests/STS/STS.Tests.ps1
@@ -12,8 +12,12 @@ Describe -Tag "Smoke" "STS" {
     }
 
     Context "Temporary Credentials" {
-
         It "Can get temporary credentials" {
+            # Get-STSSecurityToken can't be used here because it requires permanent credentials
+            if ($helper.Token -ne $null) {
+                return
+            }
+
             $creds = Get-STSSessionToken
             $creds | Should Not Be $null
             $creds.AccessKeyId | Should Not BeNullOrEmpty


### PR DESCRIPTION
## Motivation and Context

Traditionally, AWS Tools for PowerShell has been built in Jenkins CI which limits developers to run build on PRs. Having no PR checks allowed developers to pushed untested code in release branch.

## Containerizing PS build

AWS Tools for PowerShell has been challenging to build locally due to specific dependencies such as .NET Core 2.1, PowerShell 6.1.3 and Pester 4.8.1. There is separate work item for switching to from .NET Core 2.1. There are number of fixes introduced to allow PS in a container.

### Goal 1: Migrating to PowerShell 7

Following tests verifies the working of the credential chain when no AWS credentials are provided. The tests are setup by mocking the readonly field/properties in AWS .NET using PowerShell 6.1.3, which is not supported in [newer versions](https://github.com/dotnet/runtime/issues/11571#issuecomment-442675193) of .NET Core and PowerShell.

```powershell
It "should fail with no credentials set" {
    # unfortunately, this takes 15 seconds...
    { Get-EC2Instance } | Should Throw "No credentials specified or obtained from persisted/shell defaults."
}
```
```powershell
It "should fail with no credentials set" {
    # unfortunately, this takes 15 seconds...
    { Get-S3Bucket } | Should Throw "No credentials specified or obtained from persisted/shell defaults."
}
```

### Goal 2: Supporting temporary credentials for testing

Fixing/removing tests which don't support temporary AWS credentials

 AWS Tools for PowerShell tests are designed to run against permanent AWS credentials. Depending on permanent credentials is bad practices and comes with rotation maintenance.

TestHelper.ps1 is updated to incorporate temporary AWS credentials.

Why are following tests skipped?
```powershell
It "Can list jobs and get job status" {
    # Get-IEJob can't be used here because it requires permanent credentials
    if ($helper.Token -ne $null) {
        return
    }
```
```powershell
It "Can get temporary credentials" {
    # Get-STSSecurityToken can't be used here because it requires permanent credentials
    if ($helper.Token -ne $null) {
        return
    }
```
Above tests verifies the operations which are only supported by permanent credentials.

### Goal 3: Migrating to Pester 5.0

This has been put hold for now, it requires major re-structuring of tests which isn't feasible at the moment.

## Setting AWS CodeBuild CI for PR validation

AWS CodeBuild CI (`ci.codebuild.yml`) allows developers to build and test their PRs on GitHub using AWS CodeBuild. It has three parts

### 1. AWS CodeBuild CI GitHub action

On every PR request to `master` and `dev` branch and merge to `master` and `dev` branch, it executes CodeBuild project. It uses repository secrets to store role ARN. [OpenID authentication](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) is used to setup AWS credentials.

### 2. Dockerfile and CodeBuild project

CodeBuild project uses custom `buildtools/Dockerfile` container which has all the required tools installed to build and test the PRs.

Pester tests use `test-runner` AWS profile for running the tests. Therefore, the codebuild job, assumes `TEST_RUNNER_ROLE_ARN` role and sets up the `test-runner` profile and executes the tests.

CodeBuild job must have permission to assume `TEST_RUNNER_ROLE_ARN` role.

### 3. Template for infra generation

 ci.template.yml is responsible for creating infra in AWS that includes creating role for OIDC and CodeBuild project.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] CI

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-tools-for-powershell/issues [license]: http://aws.amazon.com/apache2.0/ [cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement