### PR TITLE
Add retry helper/polling logic to check for status of operation

### DIFF
--- a/tests/Include/RetryHelper.ps1
+++ b/tests/Include/RetryHelper.ps1
@@ -1,0 +1,39 @@
+function Invoke-WithRetry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$ScriptBlock,
+        
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$ValidateBlock,
+        
+        [int]$MaxRetries = 10,
+        [double]$BaseWaitSeconds = 1,
+        [double]$MaxWaitSeconds = 32,
+        [string]$OperationName = "Operation"
+    )
+
+    $retryCount = 0
+    
+    do {
+        $result = & $ScriptBlock
+        
+        if (& $ValidateBlock $result) {
+            return $result
+        }
+        
+        if ($retryCount -ge $MaxRetries) {
+            throw "$OperationName did not succeed within $MaxRetries retries"
+        }
+        
+        # Calculate exponential backoff with jitter
+        $exponentialWait = [Math]::Min($MaxWaitSeconds, $BaseWaitSeconds * [Math]::Pow(2, $retryCount))
+        $jitter = Get-Random -Minimum 0 -Maximum 1000
+        $waitTimeWithJitter = $exponentialWait + ($jitter / 1000)
+        
+        Write-Verbose "$OperationName not ready... (Attempt $($retryCount + 1) of $MaxRetries, waiting $([Math]::Round($waitTimeWithJitter, 2)) seconds)"
+        Start-Sleep -Seconds $waitTimeWithJitter
+        $retryCount++
+        
+    } while ($retryCount -lt $MaxRetries)
+}


### PR DESCRIPTION
`S3 AWSHistory Advanced Cmdlet` was failing sometimes because it was not waiting for the KMS key to be fully created before it tried to use it when creating the s3 bucket. This update makes it so it polls until the KMS key is created first before going to the next step. The retry helper can also be applied to other tests in the future.

## Description
1. Add retry logic to help with waiting until resources are created

## Motivation and Context
1. To fix flaky tests

## Testing
1. Tests in CI passed.
3. Ran this script to verify retry logic works (please note i wasnt able to directly verify that the KMS retry logic works since it doesnt happen all of the time, however, based on below script it _should_ work, since its just a generic retry)

```
# Test scenarios for Invoke-WithRetry
function Test-RetryFunction {
    # Test 1: Success on first try
    Write-Host "`nTest 1: Success on first try" -ForegroundColor Green
    $result = Invoke-WithRetry -Verbose `
        -ScriptBlock { "Success" } `
        -ValidateBlock { param($r) return $true } `
        -OperationName "Immediate Success Test"
    Write-Host "Result: $result"

    # Test 2: Success after 3 retries
    Write-Host "`nTest 2: Success after 3 retries" -ForegroundColor Green
    $attemptCount = 0
    $result = Invoke-WithRetry -Verbose `
        -ScriptBlock { 
            "Attempt $script:attemptCount"
            $script:attemptCount++
        } `
        -ValidateBlock { param($r) return $r -eq "Attempt 2" } `
        -MaxRetries 5 `
        -BaseWaitSeconds 0.1 `
        -OperationName "Delayed Success Test"
    Write-Host "Result: $result"

    # Test 3: Failure (max retries exceeded)
    Write-Host "`nTest 3: Failure (max retries exceeded)" -ForegroundColor Green
    try {
        Invoke-WithRetry -Verbose `
            -ScriptBlock { "Always fails" } `
            -ValidateBlock { param($r) return $false } `
            -MaxRetries 3 `
            -BaseWaitSeconds 0.1 `
            -OperationName "Expected Failure Test"
    }
    catch {
        Write-Host "Expected error caught: $_" -ForegroundColor Yellow
    }

    # Test 4: Test exponential backoff
    Write-Host "`nTest 4: Testing exponential backoff" -ForegroundColor Green
    $startTime = Get-Date
    try {
        Invoke-WithRetry -Verbose `
            -ScriptBlock { "Testing backoff" } `
            -ValidateBlock { param($r) return $false } `
            -MaxRetries 4 `
            -BaseWaitSeconds 1 `
            -MaxWaitSeconds 8 `
            -OperationName "Backoff Test"
    }
    catch {
        $duration = (Get-Date) - $startTime
        Write-Host "Test duration: $($duration.TotalSeconds) seconds" -ForegroundColor Yellow
    }
}

# Run all tests
Test-RetryFunction
````

```
PS C:\dev\repos\aws-tools-for-powershell\tests> Test-RetryFunction

Test 1: Success on first try
Result: Success

Test 2: Success after 3 retries
VERBOSE: Delayed Success Test not ready... (Attempt 1 of 5, waiting 0.22 seconds)
VERBOSE: Delayed Success Test not ready... (Attempt 2 of 5, waiting 0.39 seconds)
Result: Attempt 2

Test 3: Failure (max retries exceeded)
VERBOSE: Expected Failure Test not ready... (Attempt 1 of 3, waiting 0.16 seconds)
VERBOSE: Expected Failure Test not ready... (Attempt 2 of 3, waiting 0.97 seconds)
VERBOSE: Expected Failure Test not ready... (Attempt 3 of 3, waiting 1.01 seconds)

Test 4: Testing exponential backoff
VERBOSE: Backoff Test not ready... (Attempt 1 of 4, waiting 1.61 seconds)        
VERBOSE: Backoff Test not ready... (Attempt 2 of 4, waiting 2.14 seconds)
VERBOSE: Backoff Test not ready... (Attempt 3 of 4, waiting 4.16 seconds)
VERBOSE: Backoff Test not ready... (Attempt 4 of 4, waiting 8.22 seconds)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
We require a second engineer to validate the PR before merging
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code builds in Gamma and passes backward compatibility validation (required)
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed


> Note to reviewers: Please follow runbook to update the internal open source attribution tool

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-tools-for-powershell/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
