### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aws/aws-sdk-powershell-reviewers @aws/aws-sdk-dotnet-team


### PR DESCRIPTION
Adds a [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file per OSPO GitHub permissions guidance, matching the file already present on `main`.

This routes PR review assignment on the `v4.1` maintenance branch the same way the active branches handle it.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners