### PR TITLE
Fix Invoke-AWSSSOLogin failure when default profile is configured for SSO login

### DIFF
--- a/modules/AWSPowerShell/Common/Internal/SSOProfileMethods.cs
+++ b/modules/AWSPowerShell/Common/Internal/SSOProfileMethods.cs
@@ -37,6 +37,8 @@ namespace Amazon.PowerShell.Utils
 
         private const string SsoSessionProfilePrefix = "sso-session";
 
+        private const string DefaultProfileName = "default";
+
         /// <summary>
         /// Regex:
         /// - Starts with "sso-session"
@@ -94,11 +96,11 @@ namespace Amazon.PowerShell.Utils
         /// Returns a ProfileIniFile of the shared config file.
         /// </summary>
         /// <param name="this">The SharedCredentialsFile to retrieve the config file for.</param>
+        /// <param name="isDefaultProfile">When true, opens the file in permissive mode so bare [default] section headers are recognized.</param>
         /// <returns>A ProfileIniFile instance of the config file.</returns>
-        private static ProfileIniFile GetSharedConfigFile(this SharedCredentialsFile @this)
+        private static ProfileIniFile GetSharedConfigFile(this SharedCredentialsFile @this, bool isDefaultProfile = false)
         {
-            // Second parameter profileMarkerRequired is required to be true for config files, but not for general ini files.
-            return new ProfileIniFile(@this.GetSharedConfigFilePath(), true);
+            return new ProfileIniFile(@this.GetSharedConfigFilePath(), !isDefaultProfile);
         }
 
         private static void ThrowOnNullOrWhiteSpace(string name, string value)
@@ -191,8 +193,11 @@ namespace Amazon.PowerShell.Utils
                 profileProperties.Add(_regionPropertyName, profile.Region.SystemName);
             }
 
-            var configFile = sharedCredentialsFile.GetSharedConfigFile();
-            configFile.EnsureSectionExists(SSOProfileMethods.CreateProfileName(profile.Name));
+            var isDefaultProfile = profile.Name == DefaultProfileName;
+            var profileSectionName = isDefaultProfile ? DefaultProfileName : SSOProfileMethods.CreateProfileName(profile.Name);
+
+            var configFile = sharedCredentialsFile.GetSharedConfigFile(isDefaultProfile);
+            configFile.EnsureSectionExists(profileSectionName);
             configFile.EnsureSectionExists(SSOProfileMethods.CreateSsoSessionProfileName(options.SsoSession));
 
             configFile.EditSection(profile.Name, false, profileProperties); // Section must already exist to edit sso-session

--- a/modules/AWSPowerShell/Common/SSOCmdlets.cs
+++ b/modules/AWSPowerShell/Common/SSOCmdlets.cs
@@ -119,8 +119,8 @@ namespace Amazon.PowerShell.Common
                 if (!SettingsStore.TryGetProfile("default", null, out var profile))
                 {
                     this.ThrowTerminatingError(new ErrorRecord(
-                        new ArgumentException($"profile {ProfileName} not found in the shared config (~/.aws/config) file."),
-                        "ArgumentException", ErrorCategory.InvalidArgument, this.ProfileName));
+                        new ArgumentException($"default profile not found in the shared config (~/.aws/config) file."),
+                        "ArgumentException", ErrorCategory.InvalidArgument, this));
                 }
 
                 if (profile.Options.SsoSession != null && profile.Options.SsoStartUrl != null &&
@@ -132,7 +132,7 @@ namespace Amazon.PowerShell.Common
                 {
                     this.ThrowTerminatingError(new ErrorRecord(
                         new ArgumentException($"Either ProfileName or SessionName or a default profile with SSO configuration is required."),
-                        "ArgumentException", ErrorCategory.InvalidArgument, this.ProfileName));
+                        "ArgumentException", ErrorCategory.InvalidArgument, this));
                 }
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix `Initialize-AWSSSOConfiguration -ProfileName default` so it writes the profile under `[default]` section header in `~/.aws/config` instead of the `[profile default]`. Every profile uses `[profile <name>]` except the default profile, which must be just `[default]`.

Both AWS CLI and the existing `AWSLoginProfileMethods` in this project (used by `Invoke-AWSLogin`) already handle this edge case correctly.

Changes:
- `SSOProfileMethods.RegisterSsoProfileAndSession` now writes `[default]` when the profile name is `default`
- Cleanup: corrected error message at `SSOCmdlets.cs:122` that referenced `{ProfileName}` in a branch where it was always null.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
SIM: https://sim.amazon.com/issues/PowerShell-322

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally on Windows and on a fresh EC2 Windows instance:

1. **Original repro**: `Initialize-AWSSSOConfiguration -ProfileName default` followed by `Invoke-AWSSSOLogin` (no args). Verified the section is written as bare `[default]` and the no-args login succeeds.
2. **End-to-end credential resolution**: Confirmed `Get-S3Bucket` works against the SSO-configured default profile.
3. **Pre-existing keys preservation**: Pre-populated `[default]` with `region` and other keys; confirmed unrelated keys survive after running the init cmdlet (matches `aws configure sso` behavior).
4. **Non-default profile regression**: `-ProfileName myprofile` still produces `[profile myprofile]` as before.

### Dry-run
- **Dry-run ID:** `b4119f1b-f35a-4ac5-86ee-417e7173ad38`
- **Status:**
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **Failed bypass reason:**

## Breaking Changes Assessment

**No Breaking Changes**

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
We require a second engineer to validate the PR before merging
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code builds in Gamma and passes backward compatibility validation (required)
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## New/existing dependencies impact assessment, if applicable
<!--- If any dependency was added / modified / removed, please provide the following details for each package: Name, Version, and License. -->
<!-- If no new dependencies were added to this change, this section can be removed. -->

> Note to reviewers: Please follow runbook to update the internal open source attribution tool

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-tools-for-powershell/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement