### PR TITLE
Installer V2 GA Bug Fixes

### DIFF
--- a/buildtools/Test-InstallerVersion.ps1
+++ b/buildtools/Test-InstallerVersion.ps1
@@ -35,15 +35,14 @@ function Test-InstallerVersion([string]$from, [string]$to) {
 
     # get the local version of the installer
 
-    # Unload the module if it is already loaded
-    if(Get-Module -Name AWS.Tools.Installer)
-    {
-        Remove-Module -Name AWS.Tools.Installer
-    }
+    # Read ModuleVersion directly from the manifest as data. We must not Import-Module
+    # here: the source-tree manifest declares RequiredAssemblies = @('AWS.Tools.Installer.dll'),
+    # a compiled build artifact that does not exist in this source-only checkout, so
+    # Import-Module fails. Importability is validated downstream against the built module
+    # (see tests/Include/InstallerTestIncludes.ps1). This check only needs the version.
     $installerModulePath = Join-Path  "." "modules" "Installer" "AWS.Tools.Installer.psd1"
-    Import-Module $installerModulePath
-    $localInstallerModule = Get-Module -Name AWS.Tools.Installer
-    $localVersion = $localInstallerModule.Version
+    $manifest = Import-PowerShellDataFile $installerModulePath
+    [System.Version]$localVersion = $manifest.ModuleVersion
     Write-Host "Local AWS.Tools.Installer version: $localVersion"
 
     # check if the new version has 0 revision

--- a/modules/Installer/AWS.Tools.Installer.Lib/ModuleInstaller.cs
+++ b/modules/Installer/AWS.Tools.Installer.Lib/ModuleInstaller.cs
@@ -233,7 +233,9 @@ namespace Amazon.PowerShell.Installer
         /// <summary>
         /// When the caller specifies modules, build a small filtered dictionary by lookup
         /// (O(|requested|)) instead of walking all entries. Throws
-        /// <see cref="MissingModulesException"/> if any requested name is not in the archive.
+        /// <see cref="MissingModulesException"/> only when a mandatory module is absent.
+        /// Non-mandatory modules that are missing from the archive are silently skipped;
+        /// the caller detects them by comparing requested vs. returned module lists.
         /// </summary>
         private static Dictionary<string, List<string>> FilterRequested(
             Dictionary<string, List<string>> entriesByModule,
@@ -250,14 +252,20 @@ namespace Amazon.PowerShell.Installer
             // caller can derive the install's version string from a stable source.
             if (entriesByModule.ContainsKey("AWS.Tools")) requested.Add("AWS.Tools");
 
-            var missing = new List<string>();
+            var mandatorySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (mandatoryModules != null)
+                foreach (var m in mandatoryModules) mandatorySet.Add(m);
+
+            var missingMandatory = new List<string>();
             var filtered = new Dictionary<string, List<string>>(requested.Count, StringComparer.OrdinalIgnoreCase);
             foreach (var name in requested)
             {
-                if (entriesByModule.TryGetValue(name, out var list)) filtered[name] = list;
-                else missing.Add(name);
+                if (entriesByModule.TryGetValue(name, out var list))
+                    filtered[name] = list;
+                else if (mandatorySet.Contains(name))
+                    missingMandatory.Add(name);
             }
-            if (missing.Count > 0) throw new MissingModulesException(missing);
+            if (missingMandatory.Count > 0) throw new MissingModulesException(missingMandatory);
             return filtered;
         }
 

--- a/modules/Installer/Private/Install-AWSToolsModuleFromZip.ps1
+++ b/modules/Installer/Private/Install-AWSToolsModuleFromZip.ps1
@@ -98,6 +98,15 @@ function Install-AWSToolsModuleFromZip {
             )
         }
 
+        if ($ModuleNames) {
+            $installedNames = @($results | ForEach-Object { $_.Name })
+            foreach ($requested in $ModuleNames) {
+                if ($installedNames -notcontains $requested) {
+                    Write-Warning "Module '$requested' is not available in this version and was skipped."
+                }
+            }
+        }
+
         # Build the return value: a hashtable with Version, VersionString, and a
         # Modules array (Name + Version per module). Surface any non-fatal
         # warnings (e.g. PSGetModuleInfo.xml write failures) per module.

--- a/modules/Installer/Private/Resolve-AWSToolsVersion.ps1
+++ b/modules/Installer/Private/Resolve-AWSToolsVersion.ps1
@@ -79,8 +79,64 @@ function Resolve-AWSToolsVersion {
                     Major = $majorVersion
                 }
             }
-            Write-Verbose ("[$($MyInvocation.MyCommand)] No version specified, will use latest")
-            return $null
+            
+            # Resolve "latest" to a concrete version via HEAD request (same approach as wildcard resolution)
+            $majorVersion = $moduleConfig.DefaultMajorVersion
+            Write-Verbose ("[$($MyInvocation.MyCommand)] No version specified, resolving latest for major version $majorVersion")
+            
+            try {
+                # Build the URL using configuration patterns (same as wildcard path)
+                $baseUrl = $script:Config.general.CloudFront.BaseUrl
+                $path = $script:Config.general.CloudFront.Paths[$Name.Replace('.', '')]
+                
+                $zipUrl = $moduleConfig.CloudFrontUrls.ZipDownloadUrlPattern `
+                    -replace '\{baseUrl\}', $baseUrl `
+                    -replace '\{path\}', $path `
+                    -replace '\{majorVersion\}', $majorVersion
+                
+                $invokeWithRetryParams = @{
+                    ScriptBlock = { 
+                        $response = Invoke-WebRequestWithStatusHandling -Uri $zipUrl -Method 'HEAD' -TimeoutSec $Timeout
+                        
+                        if (-not $response.Success) {
+                            $customMessages = @{
+                                404 = "Latest version not found for major version $majorVersion."
+                                403 = "Latest version not found for major version $majorVersion."
+                                503 = "CloudFront service temporarily unavailable."
+                            }
+                            
+                            Get-HttpStatusErrorMessage -Response $response -Operation "resolving latest version" -CustomMessages $customMessages
+                        }
+                        
+                        return $response.RawResponse
+                    }
+                    MaxRetries = $script:Config.retry.VersionCheckMaxRetries
+                    BaseDelaySeconds = $script:Config.retry.BaseDelaySeconds
+                    OperationName = "Resolve latest version"
+                    RetryableExceptions = $script:Config.retry.RetryableExceptions.Network
+                }
+                
+                $response = Invoke-WithRetry @invokeWithRetryParams
+                $contentDisposition = $response.Headers.'Content-Disposition'
+                
+                # Handle array responses from headers
+                if ($contentDisposition -is [array]) { 
+                    $contentDisposition = $contentDisposition[0] 
+                }
+                
+                $actualVersion = $contentDisposition -replace "attachment; filename=$($moduleConfig.ModulePrefix).", '' 
+                $actualVersion = $actualVersion -replace '.zip', ''
+                $resolvedVersion = [Version]$actualVersion
+                
+                Write-Verbose ("[$($MyInvocation.MyCommand)] Resolved latest to " +
+                    "actual version: $resolvedVersion")
+                return $resolvedVersion
+            }
+            catch {
+                Write-Verbose ("[$($MyInvocation.MyCommand)] Failed to resolve latest " +
+                    "version: $($_.Exception.Message). Will use latest endpoint at download time")
+                return $null
+            }
         }
         
         # Handle wildcard patterns like "4.*" or "5.*" for AWS.Tools, "1.*" for AWS.Tools.Installer

--- a/modules/Installer/Public/Install-AWSToolsModule.ps1
+++ b/modules/Installer/Public/Install-AWSToolsModule.ps1
@@ -619,26 +619,53 @@ To suppress this warning, specify a version constraint. Alternatively, you can s
                 # Check if version is already installed BEFORE downloading to avoid unnecessary network calls
                 # This check happens AFTER ShouldProcess so WhatIf users see what would be installed
                 if (-not $SourceZipPath -and -not $Force -and $resolvedVersionObj) {
-                    # Check local filesystem first for AWS.Tools.Common
-                    $params = @{ 
-                        Path = $targetPath
-                        Name = 'AWS.Tools'
+                    # Compute the target version string once for comparison.
+                    $targetVersionString = if ($resolvedVersionObj.PSObject.Properties['SemVerString']) {
+                        $resolvedVersionObj.SemVerString
+                    } else {
+                        $resolvedVersionObj.ToString()
                     }
-                    $installedCommon = Get-InstalledAWSToolsModule @params |
-                        Where-Object { $_.Name -eq 'AWS.Tools.Common' } |
-                        Sort-Object Version -Descending |
-                        Select-Object -First 1
-                    
-                    if ($installedCommon) {
-                        # Compare installed version with target version
-                        $installedVersionString = $installedCommon.Version.ToString()
-                        $targetVersionString = if ($resolvedVersionObj.PSObject.Properties['SemVerString']) {
-                            $resolvedVersionObj.SemVerString
-                        } else {
-                            $resolvedVersionObj.ToString()
+
+                    # Enumerate installed AWS.Tools modules once (excludes AWS.Tools.Installer).
+                    $installedModulesOnDisk = Get-InstalledAWSToolsModule -Path $targetPath -Name 'AWS.Tools'
+
+                    if ($resolvedNames) {
+                        # Subset install (-Name specified): only skip when EVERY requested module is
+                        # already present at the target version. Using AWS.Tools.Common as a proxy
+                        # would wrongly skip when Common is present but a requested service module
+                        # (e.g. AWS.Tools.S3) is not yet installed.
+                        $latestByName = @{}
+                        foreach ($installedModule in $installedModulesOnDisk) {
+                            $existing = $latestByName[$installedModule.Name]
+                            if (-not $existing -or $installedModule.Version -gt $existing.Version) {
+                                $latestByName[$installedModule.Name] = $installedModule
+                            }
                         }
-                        
-                        if ($installedVersionString -eq $targetVersionString) {
+
+                        $allRequestedPresentAtTarget = $true
+                        foreach ($requestedName in $resolvedNames) {
+                            $candidate = $latestByName[$requestedName]
+                            if (-not $candidate -or $candidate.Version.ToString() -ne $targetVersionString) {
+                                $allRequestedPresentAtTarget = $false
+                                break
+                            }
+                        }
+
+                        if ($allRequestedPresentAtTarget) {
+                            Write-Verbose ("[$($MyInvocation.MyCommand)] All requested AWS Tools modules already installed at version $targetVersionString, skipping installation")
+                            Write-Host "Skipped installation: requested AWS.Tools modules version $targetVersionToInstall already installed in $targetPath. Use -Force to reinstall."
+                            return
+                        }
+                    }
+                    else {
+                        # Install-all (no -Name): every module in a release shares the release
+                        # version, so AWS.Tools.Common is a valid proxy for the whole set.
+                        $installedCommon = $installedModulesOnDisk |
+                            Where-Object { $_.Name -eq 'AWS.Tools.Common' } |
+                            Sort-Object Version -Descending |
+                            Select-Object -First 1
+
+                        if ($installedCommon -and $installedCommon.Version.ToString() -eq $targetVersionString) {
                             Write-Verbose ("[$($MyInvocation.MyCommand)] AWS Tools version $targetVersionString already installed, skipping installation")
                             Write-Host "Skipped installation: AWS.Tools.Common version $targetVersionToInstall already installed in $targetPath. Use -Force to overwrite or add missing modules."
                             return

--- a/modules/Installer/Public/Install-AWSToolsModuleV1.ps1
+++ b/modules/Installer/Public/Install-AWSToolsModuleV1.ps1
@@ -118,7 +118,7 @@ function Install-AWSToolsModuleV1 {
             }
         } | Sort-Object -Unique
 
-        if ($Name -notlike 'AWS.Tools*') {
+        if ($Name -notlike 'AWS.Tools.*') {
             throw "The Name parameter must contain only AWS.Tools modules."
         }
 

--- a/modules/Installer/Public/Uninstall-AWSToolsModule.ps1
+++ b/modules/Installer/Public/Uninstall-AWSToolsModule.ps1
@@ -566,8 +566,13 @@ function Uninstall-AWSToolsModule {
         else {
             Write-Verbose ("[$($MyInvocation.MyCommand)] No AWS.Tools modules found " +
                 "matching the specified criteria")
-            $versionInfo = if ($Version) { "version $Version" } elseif ($ExceptVersion) { "all versions except $ExceptVersion" } else { "all versions" }
-            Write-Host "Skipped uninstallation: No AWS.Tools modules found ($versionInfo) in $targetPath"
+            if ($ExceptModules -or $ExceptVersion) {
+                Write-Host "Skipped uninstallation: No other AWS.Tools module versions found to remove in $targetPath"
+            }
+            else {
+                $versionInfo = if ($Version) { "version $Version" } else { "all versions" }
+                Write-Host "Skipped uninstallation: No AWS.Tools modules found ($versionInfo) in $targetPath"
+            }
         }
         
         # Handle legacy module cleanup if requested

--- a/tests/Installer/AWS.Tools.Installer.Unit.Private.Resolve-AWSToolsVersion.Tests.ps1
+++ b/tests/Installer/AWS.Tools.Installer.Unit.Private.Resolve-AWSToolsVersion.Tests.ps1
@@ -13,7 +13,61 @@ InModuleScope AWS.Tools.Installer {
     Describe -Skip:$SkipInstallerTests -Tag "Smoke", "Low", "Medium", "High" "Installer - Resolve-AWSToolsVersion Private Function Tests" {
         
         Context "Null and Empty Version Handling" {
-            It "Should return null for null version" {
+            BeforeEach {
+                # Mock Invoke-WithRetry to simulate successful HEAD response for latest version
+                Mock Invoke-WithRetry { 
+                    param($ScriptBlock, $OperationName)
+                    if ($OperationName -eq "Resolve latest version") {
+                        return @{ 
+                            Headers = @{ 
+                                'Content-Disposition' = 'attachment; filename=AWS.Tools.5.0.233.zip' 
+                            } 
+                        }
+                    }
+                }
+            }
+            
+            It "Should resolve latest version for null version" {
+                # Act
+                $result = Resolve-AWSToolsVersion -Version $null
+                
+                # Assert
+                $result | Should -BeOfType [Version]
+                $result.ToString() | Should -Be "5.0.233"
+                
+                # Verify HEAD request was made
+                Should -Invoke Invoke-WithRetry -ParameterFilter { 
+                    $OperationName -eq "Resolve latest version" 
+                } -Times 1
+            }
+            
+            It "Should resolve latest version for empty string version" {
+                # Act
+                $result = Resolve-AWSToolsVersion -Version ""
+                
+                # Assert
+                $result | Should -BeOfType [Version]
+                $result.ToString() | Should -Be "5.0.233"
+            }
+            
+            It "Should resolve latest version for whitespace-only version" {
+                # Act
+                $result = Resolve-AWSToolsVersion -Version "   "
+                
+                # Assert
+                $result | Should -BeOfType [Version]
+                $result.ToString() | Should -Be "5.0.233"
+            }
+            
+            It "Should return null when HEAD request fails for latest version" {
+                # Arrange - Mock failure
+                Mock Invoke-WithRetry { 
+                    param($ScriptBlock, $OperationName)
+                    if ($OperationName -eq "Resolve latest version") {
+                        throw "Network error"
+                    }
+                }
+                
                 # Act
                 $result = Resolve-AWSToolsVersion -Version $null
                 
@@ -21,20 +75,17 @@ InModuleScope AWS.Tools.Installer {
                 $result | Should -BeNullOrEmpty
             }
             
-            It "Should return null for empty string version" {
-                # Act
-                $result = Resolve-AWSToolsVersion -Version ""
+            It "Should use DefaultMajorVersion from config for latest resolution" {
+                # Act - verify HEAD request is made regardless of configured major version
+                $result = Resolve-AWSToolsVersion -Name 'AWS.Tools' -Version $null
                 
                 # Assert
-                $result | Should -BeNullOrEmpty
-            }
-            
-            It "Should return null for whitespace-only version" {
-                # Act
-                $result = Resolve-AWSToolsVersion -Version "   "
+                $result | Should -BeOfType [Version]
                 
-                # Assert
-                $result | Should -BeNullOrEmpty
+                # Verify HEAD request was made with correct operation name
+                Should -Invoke Invoke-WithRetry -ParameterFilter { 
+                    $OperationName -eq "Resolve latest version" 
+                } -Times 1
             }
         }
         

--- a/tests/Installer/AWS.Tools.Installer.Unit.Public.Install-AWSToolsModule.Tests.ps1
+++ b/tests/Installer/AWS.Tools.Installer.Unit.Public.Install-AWSToolsModule.Tests.ps1
@@ -43,7 +43,8 @@ BeforeAll {
         } elseif ($Version -and $Version.Trim() -ne '') {
             return [Version]$Version
         } else {
-            return $null
+            # No version specified: resolve latest (mimics real behavior after fix)
+            return [Version]"5.0.233"
         }
     }
 
@@ -318,6 +319,28 @@ Describe -Skip:$SkipInstallerTests -Tag "Smoke", "Low", "Medium", "High" "Instal
             
             # Assert
             Should -Invoke -ModuleName AWS.Tools.Installer Get-InstalledAWSToolsModule -ParameterFilter {
+                $Name -eq 'AWS.Tools'
+            }
+            Should -Not -Invoke -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip
+        }
+        
+        It "Should skip installation when no version specified and latest is already installed" {
+            # Arrange - Resolve-AWSToolsVersion returns the latest version (5.0.233)
+            # and Get-AWSToolsModule shows that same version is already installed
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsVersion { return [Version]"5.0.233" }
+            Mock -ModuleName AWS.Tools.Installer Get-AWSToolsModule { 
+                return [PSCustomObject]@{
+                    Name = 'AWS.Tools.Common'
+                    Version = [Version]"5.0.233"
+                }
+            }
+            Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip { }
+            
+            # Act - No -Version parameter specified
+            Install-AWSToolsModule -Confirm:$false -WarningAction SilentlyContinue @script:InformationActionSplat
+            
+            # Assert - Should skip download and installation
+            Should -Invoke -ModuleName AWS.Tools.Installer Get-AWSToolsModule -ParameterFilter {
                 $Name -eq 'AWS.Tools'
             }
             Should -Not -Invoke -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip

--- a/tests/Installer/AWS.Tools.Installer.Unit.Public.Install-AWSToolsModule.Tests.ps1
+++ b/tests/Installer/AWS.Tools.Installer.Unit.Public.Install-AWSToolsModule.Tests.ps1
@@ -326,21 +326,21 @@ Describe -Skip:$SkipInstallerTests -Tag "Smoke", "Low", "Medium", "High" "Instal
         
         It "Should skip installation when no version specified and latest is already installed" {
             # Arrange - Resolve-AWSToolsVersion returns the latest version (5.0.233)
-            # and Get-AWSToolsModule shows that same version is already installed
+            # and Get-InstalledAWSToolsModule shows that same version is already installed
             Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsVersion { return [Version]"5.0.233" }
-            Mock -ModuleName AWS.Tools.Installer Get-AWSToolsModule { 
+            Mock -ModuleName AWS.Tools.Installer Get-InstalledAWSToolsModule {
                 return [PSCustomObject]@{
                     Name = 'AWS.Tools.Common'
                     Version = [Version]"5.0.233"
                 }
             }
             Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip { }
-            
+
             # Act - No -Version parameter specified
             Install-AWSToolsModule -Confirm:$false -WarningAction SilentlyContinue @script:InformationActionSplat
-            
+
             # Assert - Should skip download and installation
-            Should -Invoke -ModuleName AWS.Tools.Installer Get-AWSToolsModule -ParameterFilter {
+            Should -Invoke -ModuleName AWS.Tools.Installer Get-InstalledAWSToolsModule -ParameterFilter {
                 $Name -eq 'AWS.Tools'
             }
             Should -Not -Invoke -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip

--- a/tests/Installer/AWS.Tools.Installer.Unit.Public.Install-AWSToolsModule.Tests.ps1
+++ b/tests/Installer/AWS.Tools.Installer.Unit.Public.Install-AWSToolsModule.Tests.ps1
@@ -345,7 +345,69 @@ Describe -Skip:$SkipInstallerTests -Tag "Smoke", "Low", "Medium", "High" "Instal
             }
             Should -Not -Invoke -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip
         }
-        
+
+        It "Should install a named module that is missing even when AWS.Tools.Common is already present at the target version" {
+            # Arrange: Common is installed at the target version but the requested
+            # service module (AWS.Tools.S3) is not. The skip must NOT fire — Common
+            # presence is not a proxy for the requested module's presence.
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsVersion { return [Version]"5.0.154" }
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsModuleNames { return @('AWS.Tools.Common', 'AWS.Tools.S3') }
+            Mock -ModuleName AWS.Tools.Installer Get-InstalledAWSToolsModule {
+                return @([PSCustomObject]@{ Name = 'AWS.Tools.Common'; Version = [Version]"5.0.154" })
+            }
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsZipSource { Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "AWS.Tools.zip" }
+            Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip { @{ Version = "5.0.154"; Modules = @() } }
+            Mock -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule { }
+
+            # Act
+            Install-AWSToolsModule -Name 'AWS.Tools.S3' -Version "5.0.154" -Confirm:$false -WarningAction SilentlyContinue @script:InformationActionSplat
+
+            # Assert
+            Should -Invoke -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip -Times 1
+        }
+
+        It "Should skip a named install when every requested module is already present at the target version" {
+            # Arrange: both Common and the requested service module are installed at
+            # the target version, so the install is genuinely redundant.
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsVersion { return [Version]"5.0.154" }
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsModuleNames { return @('AWS.Tools.Common', 'AWS.Tools.S3') }
+            Mock -ModuleName AWS.Tools.Installer Get-InstalledAWSToolsModule {
+                return @(
+                    [PSCustomObject]@{ Name = 'AWS.Tools.Common'; Version = [Version]"5.0.154" }
+                    [PSCustomObject]@{ Name = 'AWS.Tools.S3'; Version = [Version]"5.0.154" }
+                )
+            }
+            Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip { }
+
+            # Act
+            Install-AWSToolsModule -Name 'AWS.Tools.S3' -Version "5.0.154" -Confirm:$false -WarningAction SilentlyContinue @script:InformationActionSplat
+
+            # Assert
+            Should -Not -Invoke -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip
+        }
+
+        It "Should install a named module set when one requested module is present but another is on a different version" {
+            # Arrange: Common matches the target but the requested S3 is on an older
+            # version, so the set is not fully satisfied and the install must proceed.
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsVersion { return [Version]"5.0.154" }
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsModuleNames { return @('AWS.Tools.Common', 'AWS.Tools.S3') }
+            Mock -ModuleName AWS.Tools.Installer Get-InstalledAWSToolsModule {
+                return @(
+                    [PSCustomObject]@{ Name = 'AWS.Tools.Common'; Version = [Version]"5.0.154" }
+                    [PSCustomObject]@{ Name = 'AWS.Tools.S3'; Version = [Version]"5.0.100" }
+                )
+            }
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsZipSource { Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "AWS.Tools.zip" }
+            Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip { @{ Version = "5.0.154"; Modules = @() } }
+            Mock -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule { }
+
+            # Act
+            Install-AWSToolsModule -Name 'AWS.Tools.S3' -Version "5.0.154" -Confirm:$false -WarningAction SilentlyContinue @script:InformationActionSplat
+
+            # Assert
+            Should -Invoke -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip -Times 1
+        }
+
         It "Should install if version already exists with Force" {
             # Arrange
             Mock -ModuleName AWS.Tools.Installer Test-AWSToolsVersionInstalled { $false }

--- a/tests/Installer/AWS.Tools.Installer.Unit.Public.Uninstall-AWSToolsModule.Tests.ps1
+++ b/tests/Installer/AWS.Tools.Installer.Unit.Public.Uninstall-AWSToolsModule.Tests.ps1
@@ -467,4 +467,53 @@ Describe -Skip:$SkipInstallerTests -Tag "Smoke", "Low", "Medium", "High" "Instal
             }
         }
     }
+
+    Context "No Modules To Process Messaging" {
+        BeforeEach {
+            # No imported modules, no modules found on disk
+            Mock -ModuleName AWS.Tools.Installer Get-Module { @() }
+            Mock -ModuleName AWS.Tools.Installer Get-ModulesToProcess { @{ Regular = @(); Installer = @() } }
+            Mock -ModuleName AWS.Tools.Installer Write-Host { }
+        }
+
+        It "Should report no other versions to remove when ExceptVersion is specified" {
+            # Act
+            Uninstall-AWSToolsModule -ExceptVersion "5.0.241" -Confirm:$false -WarningAction SilentlyContinue @script:InformationActionSplat
+
+            # Assert
+            Should -Invoke -ModuleName AWS.Tools.Installer Write-Host -Times 1 -ParameterFilter {
+                $Object -like "Skipped uninstallation: No other AWS.Tools module versions found to remove in *"
+            }
+        }
+
+        It "Should report no other versions to remove when ExceptModules is specified" {
+            # Act
+            Uninstall-AWSToolsModule -ExceptModules @(@{ Name = 'AWS.Tools.Common'; Version = '5.0.241' }) -Confirm:$false -WarningAction SilentlyContinue @script:InformationActionSplat
+
+            # Assert
+            Should -Invoke -ModuleName AWS.Tools.Installer Write-Host -Times 1 -ParameterFilter {
+                $Object -like "Skipped uninstallation: No other AWS.Tools module versions found to remove in *"
+            }
+        }
+
+        It "Should report no modules found when no exclusion filter is specified" {
+            # Act
+            Uninstall-AWSToolsModule -Confirm:$false -WarningAction SilentlyContinue @script:InformationActionSplat
+
+            # Assert
+            Should -Invoke -ModuleName AWS.Tools.Installer Write-Host -Times 1 -ParameterFilter {
+                $Object -like "Skipped uninstallation: No AWS.Tools modules found (all versions) in *"
+            }
+        }
+
+        It "Should report no modules found for a specific version not installed" {
+            # Act
+            Uninstall-AWSToolsModule -Version "4.1.0" -Confirm:$false -WarningAction SilentlyContinue @script:InformationActionSplat
+
+            # Assert
+            Should -Invoke -ModuleName AWS.Tools.Installer Write-Host -Times 1 -ParameterFilter {
+                $Object -like "Skipped uninstallation: No AWS.Tools modules found (version 4.1.0*) in *"
+            }
+        }
+    }
 }

--- a/tests/dotnet/Installer.Tests/ModuleInstallerTests.cs
+++ b/tests/dotnet/Installer.Tests/ModuleInstallerTests.cs
@@ -69,19 +69,39 @@ namespace Amazon.PowerShell.Installer.Tests
         }
 
         [Fact]
-        public void ExtractAndInstall_MissingModule_ThrowsTyped()
+        public void ExtractAndInstall_MissingMandatoryModule_ThrowsTyped()
         {
             var zip = Fixtures.BuildSyntheticZip(Path.Combine(_tempRoot, "AWS.Tools.zip"),
-                ("AWS.Tools.Common", "5.0.151"),
                 ("AWS.Tools.S3", "5.0.151"));
             var target = Path.Combine(_tempRoot, "modules");
 
             var ex = Assert.Throws<MissingModulesException>(() =>
                 ModuleInstaller.ExtractAndInstall(zip, target,
-                    moduleNames: new[] { "AWS.Tools.NotARealModule" },
-                    mandatoryModules: null));
+                    moduleNames: new[] { "AWS.Tools.S3" },
+                    mandatoryModules: new[] { "AWS.Tools.Common" }));
 
-            Assert.Contains("AWS.Tools.NotARealModule", ex.MissingModules);
+            Assert.Contains("AWS.Tools.Common", ex.MissingModules);
+        }
+
+        [Fact]
+        public void ExtractAndInstall_MissingNonMandatoryModule_SkippedNotThrown()
+        {
+            // Simulates the Update-AWSToolsModule scenario: a module that was installed locally
+            // (e.g. AWS.Tools.IoTEvents) no longer exists in the target version's archive.
+            // The install should succeed for the modules that DO exist.
+            var zip = Fixtures.BuildSyntheticZip(Path.Combine(_tempRoot, "AWS.Tools.zip"),
+                ("AWS.Tools.Common", "5.0.151"),
+                ("AWS.Tools.S3", "5.0.151"));
+            var target = Path.Combine(_tempRoot, "modules");
+
+            var results = ModuleInstaller.ExtractAndInstall(zip, target,
+                moduleNames: new[] { "AWS.Tools.S3", "AWS.Tools.IoTEvents", "AWS.Tools.Panorama" },
+                mandatoryModules: new[] { "AWS.Tools.Common" });
+
+            Assert.Contains(results, r => r.Name == "AWS.Tools.Common");
+            Assert.Contains(results, r => r.Name == "AWS.Tools.S3");
+            Assert.DoesNotContain(results, r => r.Name == "AWS.Tools.IoTEvents");
+            Assert.DoesNotContain(results, r => r.Name == "AWS.Tools.Panorama");
         }
 
         [Fact]


### PR DESCRIPTION
# Rev 6

The V2 installer manifest declares RequiredAssemblies = 'AWS.Tools.Installer.dll', a build artifact absent in the source-only verify-installer-version CI checkout, so  Import-Module failed with "Could not load file or assembly". Read ModuleVersion via  Import-PowerShellDataFile instead; module importability is validated downstream against the built module in the Pester suite.

# Rev 5

Fix: named module install no longer skipped when only AWS.Tools.Common is present

  Before downloading the zip, Install-AWSToolsModule checks whether the target version is already installed and, if so,
  skips the download. That check used AWS.Tools.Common as a proxy for the whole install. On a subset install (-Name
  specified), this wrongly skipped installation when Common was present at the target version but a requested service
  module (e.g. AWS.Tools.S3) was not — telling the user to re-run with -Force instead of installing what they asked for.

  The skip now branches on scope:
  - -Name specified: skip only when every requested module is already present at the resolved version; otherwise
  install.
  - No -Name (install-all): unchanged — Common remains a valid proxy since all modules in a release share the release
  version.

  Preserves the idempotency optimization (repeat installs still skip the ~100 MB download) while ensuring -Name S3
  always ends with S3 installed.

  Adds 3 regression tests: named module missing while Common present (installs), named set fully satisfied (skips),
  named set partially on a stale version (installs).

# Rev 4

Fix: Clarify the cleanup message when no other AWS.Tools versions remain.

When `Uninstall-AWSToolsModule` runs with an exclusion filter (`-ExceptVersion` or `-ExceptModules`) and the only modules present are the excluded ones, it previously reported `Skipped uninstallation: No AWS.Tools modules found (all versions)`, which is misleading because the modules *are* installed. This message also surfaces through `Install-AWSToolsModule -CleanUp`, which calls `Uninstall-AWSToolsModule -ExceptModules` under the hood — so a customer who just installed (or rolled back to) a version saw "No AWS.Tools modules found" even though that version was present.

It now reports `Skipped uninstallation: No other AWS.Tools module versions found to remove` when an exclusion filter is active, while keeping the original `No AWS.Tools modules found (<version info>)` message for direct uninstalls with no filter. The `Skipped uninstallation:` prefix is kept on both branches so the line reads correctly whether invoked directly or under the hood by `-CleanUp`.

Added unit tests covering all four messaging branches (`-ExceptVersion`, `-ExceptModules`, no-filter, and specific-version-not-found).

# Rev 3

Fixed regression where [installed modules for discontinued services causes Update-AWSToolsModule to fail] - internal task PowerShell-692

# Rev 2

Fix: Skip installation when latest version already installed (no -Version parameter specified)

Resolve-AWSToolsVersion now makes a HEAD request to CloudFront's latest
endpoint when no version is specified, returning a concrete [Version] object
instead of null. This allows the already-installed check in
Install-AWSToolsModule to detect and skip redundant installations—matching
the existing behavior when a wildcard version (e.g., 5.*) is used.

On network failure, gracefully falls back to null so installation still
proceeds via the latest endpoint at download time.

# Rev 1
## Description

Restores the `-notlike` validation pattern from `'AWS.Tools*'` back to `'AWS.Tools.*'` in `Install-AWSToolsModuleV1.ps1`. The dot was inadvertently dropped when the V1 replica was created.

## Motivation and Context

The V1 replica should be a faithful copy of the original `Install-AWSToolsModule` behavior.

## Testing

Verified by diffing `Install-AWSToolsModuleV1.ps1` on `feature/installer-v2` against the original `Install-AWSToolsModule` function in the psm1.

### Dry-run
- **Dry-run ID:** internal b5ca3fe5-2287-4f47-afc6-528708516862 (7/13/26)
- **Status:**
  - [x] Pending
  - [ ] Completed successfully
  - [ ] Failed
- **Failed bypass reason:**

## Breaking Changes Assessment

No breaking changes. This restores the original validation behavior.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My code builds in Gamma and passes backward compatibility validation (required)
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
