### PR TITLE
Publish AWS.Tools.Installer reference docs to a version-specific URL

### DIFF
--- a/generator/AWSPSGeneratorLib/Generators/WebHelpGenerator.cs
+++ b/generator/AWSPSGeneratorLib/Generators/WebHelpGenerator.cs
@@ -619,8 +619,8 @@ namespace AWSPowerShellGenerator.Generators
         // change and no hand-edited HTML.
         private void WriteInstallerWebHelp(string webFilesRoot)
         {
-            const string versionToken = "%INSTALLER_VERSION%";
-            const string docsRootToken = "%INSTALLER_DOCS_ROOT%";
+            const string versionToken = "{INSTALLER_VERSION}";
+            const string docsRootToken = "{INSTALLER_DOCS_ROOT}";
 
             var installerVersion = ReadInstallerModuleVersion();
             var majorVersion = GetInstallerMajorVersion(installerVersion);

--- a/generator/AWSPSGeneratorLib/Generators/WebHelpGenerator.cs
+++ b/generator/AWSPSGeneratorLib/Generators/WebHelpGenerator.cs
@@ -623,7 +623,7 @@ namespace AWSPowerShellGenerator.Generators
             const string docsRootToken = "%INSTALLER_DOCS_ROOT%";
 
             var installerVersion = ReadInstallerModuleVersion();
-            var majorVersion = installerVersion.Split('.')[0];
+            var majorVersion = GetInstallerMajorVersion(installerVersion);
             // Relative path within /powershell/ that the installer docs deploy to. The Catapult
             // docs step lifts the installer/ folder to sit alongside the versioned reference tree.
             var docsRoot = $"powershell/installer/v{majorVersion}/reference";
@@ -633,7 +633,8 @@ namespace AWSPowerShellGenerator.Generators
             var sourceLocation = Directory.GetParent(typeof(PsHelpGenerator).Assembly.Location).FullName;
             var helpMaterials = Path.Combine(sourceLocation, "..", "..", "..", "..", "AWSPSGeneratorLib", "HelpMaterials", "WebHelp");
             var installerSource = Path.Combine(helpMaterials, "InstallerContent");
-            var resourcesSource = Path.Combine(helpMaterials, "StaticContent", "resources");
+            var staticContentSource = Path.Combine(helpMaterials, "StaticContent");
+            var resourcesSource = Path.Combine(staticContentSource, "resources");
 
             // The installer subtree is generated under installer/v{major}/reference within the doc
             // output. The Catapult docs artifact step relocates installer/ to the /powershell/ root
@@ -649,20 +650,44 @@ namespace AWSPowerShellGenerator.Generators
             IOUtils.DirectoryCopy(installerSource, installerOutput, true);
             IOUtils.DirectoryCopy(resourcesSource, Path.Combine(installerOutput, "resources"), true);
 
+            // The installer pages link to feedbackyes/no.html and favicon.ico relative to their own
+            // reference root. In the main tree these live at the reference root (copied by
+            // CopyWebHelpStaticFiles); the installer subtree needs its own copies so those links
+            // resolve. favicon.ico is binary and copied as-is; the feedback pages are HTML and get
+            // the same token/URL substitution as the rest of the subtree (below).
+            foreach (var sharedFile in new[] { "feedbackyes.html", "feedbackno.html", "favicon.ico" })
+            {
+                var src = Path.Combine(staticContentSource, sharedFile);
+                if (File.Exists(src))
+                    File.Copy(src, Path.Combine(installerOutput, sharedFile), true);
+            }
+
             var tokens = new Dictionary<string, string>
             {
                 { versionToken, installerVersion },
                 { docsRootToken, docsRoot }
             };
 
+            // Preserve the UTF-8 BOM used by every other page in the doc set (File.ReadAllText strips
+            // it from the string, File.WriteAllText would otherwise write no BOM).
+            var utf8WithBom = new UTF8Encoding(true);
+
             foreach (var htmlFile in Directory.GetFiles(installerOutput, "*.html", SearchOption.AllDirectories))
             {
                 var content = File.ReadAllText(htmlFile);
                 foreach (var token in tokens)
                     content = content.Replace(token.Key, token.Value);
-                File.WriteAllText(htmlFile, content);
+                // The shared feedback pages reference the reference root with a hardcoded
+                // /powershell/v5/reference path rather than the token; repoint those to the
+                // installer docs root as well so their canonical URL and topic links are correct.
+                content = content.Replace("powershell/v5/reference", docsRoot);
+                File.WriteAllText(htmlFile, content, utf8WithBom);
             }
         }
+
+        // Default installer docs version used when the manifest is missing or unparseable, so a
+        // doc build never fails outright over the version lookup.
+        internal const string DefaultInstallerVersion = "1.0.0";
 
         // Reads ModuleVersion from the AWS.Tools.Installer module manifest. The manifest is the
         // canonical source of truth for the installer version and is always available in the source
@@ -670,22 +695,37 @@ namespace AWSPowerShellGenerator.Generators
         private string ReadInstallerModuleVersion()
         {
             var manifestPath = Path.Combine(Options.RootPath, "modules", "Installer", "AWS.Tools.Installer.psd1");
-            if (File.Exists(manifestPath))
+            if (!File.Exists(manifestPath))
             {
-                var manifestContent = File.ReadAllText(manifestPath);
-                // Match the top-level ModuleVersion assignment, e.g. ModuleVersion = '1.0.3'.
-                var match = Regex.Match(manifestContent, @"^\s*ModuleVersion\s*=\s*'([^']+)'", RegexOptions.Multiline);
-                if (match.Success)
-                    return match.Groups[1].Value;
-
-                Console.WriteLine("WARNING: Could not find ModuleVersion in '{0}'; defaulting installer docs version to 1.0.0", manifestPath);
-            }
-            else
-            {
-                Console.WriteLine("WARNING: Installer module manifest not found at '{0}'; defaulting installer docs version to 1.0.0", manifestPath);
+                Console.WriteLine("WARNING: Installer module manifest not found at '{0}'; defaulting installer docs version to {1}", manifestPath, DefaultInstallerVersion);
+                return DefaultInstallerVersion;
             }
 
-            return "1.0.0";
+            var version = ExtractModuleVersion(File.ReadAllText(manifestPath));
+            if (version == null)
+                Console.WriteLine("WARNING: Could not find ModuleVersion in '{0}'; defaulting installer docs version to {1}", manifestPath, DefaultInstallerVersion);
+
+            return version ?? DefaultInstallerVersion;
+        }
+
+        // Extracts the top-level ModuleVersion value (e.g. "1.0.3") from a .psd1 manifest's text, or
+        // null if not present. Anchored to the start of a line so nested ModuleVersion entries under
+        // RequiredModules (which are indented differently in intent but can share leading whitespace)
+        // are not matched ahead of the top-level declaration - Regex.Match returns the first match,
+        // and the top-level ModuleVersion always precedes the RequiredModules block in the manifest.
+        internal static string ExtractModuleVersion(string manifestContent)
+        {
+            if (string.IsNullOrEmpty(manifestContent))
+                return null;
+
+            var match = Regex.Match(manifestContent, @"^\s*ModuleVersion\s*=\s*'([^']+)'", RegexOptions.Multiline);
+            return match.Success ? match.Groups[1].Value : null;
+        }
+
+        // Derives the major-version path segment value (e.g. "1") from an installer version string.
+        internal static string GetInstallerMajorVersion(string installerVersion)
+        {
+            return installerVersion.Split('.')[0];
         }
 
         private void CreateVersionInfoFile(string path)

--- a/generator/AWSPSGeneratorLib/Generators/WebHelpGenerator.cs
+++ b/generator/AWSPSGeneratorLib/Generators/WebHelpGenerator.cs
@@ -113,6 +113,7 @@ namespace AWSPowerShellGenerator.Generators
                     CleanWebHelpOutputFolder(OutputFolder);
                     CopyWebHelpStaticFiles(OutputFolder);
                     CreateVersionInfoFile(Path.Combine(OutputFolder, "items"));
+                    WriteInstallerWebHelp(OutputFolder);
 
                     var tocWriter = new TOCWriter(Options, OutputFolder);
                     tocWriter.AddFixedSection();
@@ -603,6 +604,88 @@ namespace AWSPowerShellGenerator.Generators
 
             var sourceLocation = Directory.GetParent(typeof(PsHelpGenerator).Assembly.Location).FullName;
             IOUtils.DirectoryCopy(Path.Combine(sourceLocation, "..", "..", "..", "..", "AWSPSGeneratorLib", "HelpMaterials", "WebHelp", "StaticContent"), webFilesRoot, true);
+        }
+
+        // Reference documentation for the AWS.Tools.Installer cmdlets is published to its own
+        // version-specific subtree, /powershell/installer/v{majorVersion}/reference/, so that
+        // successive installer major versions can coexist independently of the AWS Tools for
+        // PowerShell version line. The subtree is self-contained (its own frameset, TOC, summary
+        // page, cmdlet pages and a private copy of the shared resources) so that it deploys as a
+        // sibling of the main reference tree. The installer version - both the "v{major}" path
+        // segment and the version string rendered on each page - is read from the installer module
+        // manifest (AWS.Tools.Installer.psd1), which is the canonical source of truth and is always
+        // present in the source tree at doc-generation time. This means the same implementation
+        // publishes V1 today and, once the V2 installer merges, V2 automatically - with no code
+        // change and no hand-edited HTML.
+        private void WriteInstallerWebHelp(string webFilesRoot)
+        {
+            const string versionToken = "%INSTALLER_VERSION%";
+            const string docsRootToken = "%INSTALLER_DOCS_ROOT%";
+
+            var installerVersion = ReadInstallerModuleVersion();
+            var majorVersion = installerVersion.Split('.')[0];
+            // Relative path within /powershell/ that the installer docs deploy to. The Catapult
+            // docs step lifts the installer/ folder to sit alongside the versioned reference tree.
+            var docsRoot = $"powershell/installer/v{majorVersion}/reference";
+
+            Console.WriteLine("Generating AWS.Tools.Installer web help (version {0}) at {1}", installerVersion, docsRoot);
+
+            var sourceLocation = Directory.GetParent(typeof(PsHelpGenerator).Assembly.Location).FullName;
+            var helpMaterials = Path.Combine(sourceLocation, "..", "..", "..", "..", "AWSPSGeneratorLib", "HelpMaterials", "WebHelp");
+            var installerSource = Path.Combine(helpMaterials, "InstallerContent");
+            var resourcesSource = Path.Combine(helpMaterials, "StaticContent", "resources");
+
+            // The installer subtree is generated under installer/v{major}/reference within the doc
+            // output. The Catapult docs artifact step relocates installer/ to the /powershell/ root
+            // so it publishes to /powershell/installer/v{major}/reference/.
+            var installerOutput = Path.Combine(webFilesRoot, "installer", $"v{majorVersion}", "reference");
+
+            if (Directory.Exists(installerOutput))
+                Directory.Delete(installerOutput, true);
+            Directory.CreateDirectory(installerOutput);
+
+            // Copy the templated pages (index.html, TOC.html and items/*.html) and a private copy of
+            // the shared resources so the subtree is fully self-contained.
+            IOUtils.DirectoryCopy(installerSource, installerOutput, true);
+            IOUtils.DirectoryCopy(resourcesSource, Path.Combine(installerOutput, "resources"), true);
+
+            var tokens = new Dictionary<string, string>
+            {
+                { versionToken, installerVersion },
+                { docsRootToken, docsRoot }
+            };
+
+            foreach (var htmlFile in Directory.GetFiles(installerOutput, "*.html", SearchOption.AllDirectories))
+            {
+                var content = File.ReadAllText(htmlFile);
+                foreach (var token in tokens)
+                    content = content.Replace(token.Key, token.Value);
+                File.WriteAllText(htmlFile, content);
+            }
+        }
+
+        // Reads ModuleVersion from the AWS.Tools.Installer module manifest. The manifest is the
+        // canonical source of truth for the installer version and is always available in the source
+        // tree when the docs are generated.
+        private string ReadInstallerModuleVersion()
+        {
+            var manifestPath = Path.Combine(Options.RootPath, "modules", "Installer", "AWS.Tools.Installer.psd1");
+            if (File.Exists(manifestPath))
+            {
+                var manifestContent = File.ReadAllText(manifestPath);
+                // Match the top-level ModuleVersion assignment, e.g. ModuleVersion = '1.0.3'.
+                var match = Regex.Match(manifestContent, @"^\s*ModuleVersion\s*=\s*'([^']+)'", RegexOptions.Multiline);
+                if (match.Success)
+                    return match.Groups[1].Value;
+
+                Console.WriteLine("WARNING: Could not find ModuleVersion in '{0}'; defaulting installer docs version to 1.0.0", manifestPath);
+            }
+            else
+            {
+                Console.WriteLine("WARNING: Installer module manifest not found at '{0}'; defaulting installer docs version to 1.0.0", manifestPath);
+            }
+
+            return "1.0.0";
         }
 
         private void CreateVersionInfoFile(string path)

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/TOC.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/TOC.html
@@ -1,0 +1,66 @@
+﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html lang="en-GB">
+<head>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <meta name="guide-name" content="Cmdlet Reference" />
+    <meta name="service-name" content="AWS Tools for PowerShell" />
+    <link rel="stylesheet" type="text/css" href="./resources/tocstyle.css" media="screen">
+    <title>AWS.Tools.Installer Reference - Table of Contents | AWS Tools for PowerShell</title>
+</head>
+
+<body>
+    <a href="https://docs.aws.amazon.com/" title="AWS Documentation Home" target="_top">
+        <img id="awslogo" src="./resources/blank.gif" title="AWS Documentation Home" alt="AWS Documentation Home" />
+    </a>
+    <div id="toc"><ul class="awstoc"><li class="nav" id="Installer_cmdlets" onclick="updateContentPane('./items/Installer_cmdlets.html')"><a class="nav" href="./items/Installer_cmdlets.html" onclick="updateContentPane('./items/Installer_cmdlets.html')" target="contentpane">Installation</a><ul><li id="Install-AWSToolsModule" class="nav leaf"><a class="nav" href="./items/Install-AWSToolsModule.html" onclick="updateContentPane('./items/Install-AWSToolsModule.html')" target="contentpane">Install-AWSToolsModule</a></li><li id="Uninstall-AWSToolsModule" class="nav leaf"><a class="nav" href="./items/Uninstall-AWSToolsModule.html" onclick="updateContentPane('./items/Uninstall-AWSToolsModule.html')" target="contentpane">Uninstall-AWSToolsModule</a></li><li id="Update-AWSToolsModule" class="nav leaf"><a class="nav" href="./items/Update-AWSToolsModule.html" onclick="updateContentPane('./items/Update-AWSToolsModule.html')" target="contentpane">Update-AWSToolsModule</a></li></ul></li></ul></div>
+
+    <script type="text/javascript" src="./resources/jquery.min.js"></script>
+    <script type="text/javascript">
+        jQuery.noConflict();
+    </script>
+    <script type="text/javascript" src="./resources/parseuri.js"></script>
+    <script type="text/javascript" src="./resources/tocscript.js"></script>
+    <script type="text/javascript">
+        jQuery(function ($) {
+            AWSTOCObj.init("div#toc");
+
+            var params = parseUri($(window.parent.location).attr('href')).queryKey;
+            if (params && params.page) {
+                AWSTOCObj.setContentPane("./items/" + params.page);
+            } else {
+                AWSTOCObj.setContentPane("./items/Installer_cmdlets.html");
+            }
+
+            if (params && params.tocid) {
+                var li = $("li#" + params.tocid);
+                var tocItem = li.children("a.nav");
+
+                var parentNav = $(li).parents("li.nav");
+                while (parentNav.length != 0) {
+                    AWSTOCObj.expandTOCGroup(parentNav);
+                    parentNav = $(parentNav).parents("li.nav");
+                }
+
+                AWSTOCObj.setActiveTopic(tocItem);
+                AWSTOCObj.toggleTOCGroup(li);
+            }
+
+            $("li.nav").click(function (event) {
+                event.stopPropagation();
+                AWSTOCObj.clearActiveTopic();
+
+                var tocLink = $(this).children("a.nav");
+                if ($(this).hasClass("leaf")) {
+                    AWSTOCObj.setActiveTopic(tocLink);
+                } else {
+                    var prevExpanded = $(this).siblings("li.expanded");
+                    if (prevExpanded.length > 0) {
+                        AWSTOCObj.collapseTOCGroup(prevExpanded);
+                    }
+                    AWSTOCObj.toggleTOCGroup($(this));
+                }
+            });
+        });
+    </script>
+</body>
+</html>

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/index.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/index.html
@@ -8,7 +8,7 @@
         <meta name="description" content="AWS.Tools.Installer Cmdlet Reference Documentation">
         <meta name="guide-name" content="Cmdlet Reference">
         <meta name="service-name" content="AWS Tools for PowerShell">
-        <link rel="canonical" href="https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/index.html">
+        <link rel="canonical" href="https://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/index.html">
         <link rel="stylesheet" type="text/css" href="./resources/style.css" media="screen">
         <link rel="stylesheet" type="text/css" href="./resources/psstyle.css" media="screen">
 		<link rel="shortcut icon" href="favicon.ico"/>

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/index.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/index.html
@@ -1,0 +1,20 @@
+﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+
+<html lang="en-GB">
+
+    <head>
+        <title>AWS.Tools.Installer Reference</title>
+        <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+        <meta name="description" content="AWS.Tools.Installer Cmdlet Reference Documentation">
+        <meta name="guide-name" content="Cmdlet Reference">
+        <meta name="service-name" content="AWS Tools for PowerShell">
+        <link rel="canonical" href="https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/index.html">
+        <link rel="stylesheet" type="text/css" href="./resources/style.css" media="screen">
+        <link rel="stylesheet" type="text/css" href="./resources/psstyle.css" media="screen">
+		<link rel="shortcut icon" href="favicon.ico"/>
+    </head>
+    <frameset cols="350,*">
+        <frame name="TOC" src="./TOC.html" />
+        <frame name="contentpane" />
+    </frameset>
+</html>

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Install-AWSToolsModule.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Install-AWSToolsModule.html
@@ -12,7 +12,7 @@
     <title>AWS.Tools.Installer: Install-AWSToolsModule Cmdlet | AWS Tools for PowerShell</title>
     <script type="text/javascript" src="/assets/js/awsdocs-boot.js"></script>
     <meta name="aws-tocid" content="Install-AWSToolsModule"/>
-    <link rel="canonical" href="https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/items/Install-AWSToolsModule.html"/>
+    <link rel="canonical" href="https://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/items/Install-AWSToolsModule.html"/>
 </head>
 
 <body>
@@ -439,7 +439,7 @@
                 </div>
                 <div class="sectionbody">
                     <div class="versioninfo">
-                        <p><strong>AWS.Tools.Installer: </strong><span id="assemblyVersion">%INSTALLER_VERSION%</span></p>
+                        <p><strong>AWS.Tools.Installer: </strong><span id="assemblyVersion">{INSTALLER_VERSION}</span></p>
                     </div>
                 </div>
             </div>
@@ -450,11 +450,11 @@
                 <span class="divider">&nbsp;</span>
                 <!-- BEGIN-FEEDBACK-SECTION --><span class="feedback"><span class="feedbackLinks">
                         <!-- BEGIN-FEEDBACK-SECTION -->Did this page help you?&nbsp;&nbsp;<a
-                            href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackyes.html?topic_id=Install-AWSToolsModule"
+                            href="http://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/feedbackyes.html?topic_id=Install-AWSToolsModule"
                             target="_parent">Yes</a>&nbsp;&nbsp;<a
-                            href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackno.html?topic_id=Install-AWSToolsModule"
+                            href="http://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/feedbackno.html?topic_id=Install-AWSToolsModule"
                             target="_parent">No</a>&nbsp;&nbsp;&nbsp;<a
-                            href="https://docs.aws.amazon.com/forms/aws-doc-feedback?service_name=PowerShell-Ref&amp;topic_url=https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/items/Install-AWSToolsModule.html"
+                            href="https://docs.aws.amazon.com/forms/aws-doc-feedback?service_name=PowerShell-Ref&amp;topic_url=https://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/items/Install-AWSToolsModule.html"
                             target="_parent">Tell us about it...</a><!-- END-FEEDBACK-SECTION --></span></span>
                 <!-- END-FEEDBACK-SECTION -->
                 <div id="awsdocs-legal-zone-copyright"></div>

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Install-AWSToolsModule.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Install-AWSToolsModule.html
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -8,11 +8,11 @@
     <link rel="stylesheet" type="text/css" href="../resources/syntaxhighlighter/shCore.css">
     <link rel="stylesheet" type="text/css" href="../resources/syntaxhighlighter/shThemeDefault.css">
     <link rel="stylesheet" type="text/css" href="../resources/psstyle.css" />
-    <meta name="description" content="This cmdlet uses Install-Module to update all AWS.Tools modules.">
-    <title>AWS.Tools.Installer: Update-AWSToolsModule Cmdlet | AWS Tools for PowerShell</title>
+    <meta name="description" content="Install AWS.Tools modules.">
+    <title>AWS.Tools.Installer: Install-AWSToolsModule Cmdlet | AWS Tools for PowerShell</title>
     <script type="text/javascript" src="/assets/js/awsdocs-boot.js"></script>
-    <meta name="aws-tocid" content="Update-AWSToolsModule"/>
-    <link rel="canonical" href="https://docs.aws.amazon.com/powershell/v5/reference/items/Update-AWSToolsModule.html"/>
+    <meta name="aws-tocid" content="Install-AWSToolsModule"/>
+    <link rel="canonical" href="https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/items/Install-AWSToolsModule.html"/>
 </head>
 
 <body>
@@ -28,7 +28,7 @@
     <!-- END-SECTION -->
     <div id="pageHeader">
         <div id="titles">
-            <h1>Update-AWSToolsModule Cmdlet</h1>
+            <h1>Install-AWSToolsModule Cmdlet</h1>
             <h2>
                 <div>Available in <a
                         href="https://www.powershellgallery.com/packages/AWS.Tools.Installer/"
@@ -73,7 +73,7 @@
                 </div>
             </div>
             <div class="sectionbody">
-                <div class="synopsis">Updates all currently installed AWS.Tools modules.</div>
+                <div class="synopsis">Installs AWS.Tools modules.</div>
             </div>
         </div>
         <div>
@@ -84,7 +84,7 @@
             </div>
             <div class="sectionbody">
                 <div class="syntax">
-                    <pre><div class="syntaxblock"><div class="cmdlet">Update-AWSToolsModule</div><div class="paramlist"><div class="wrappedParam">-RequiredVersion &lt;System.Version&gt;</div><div class="wrappedParam">-MaximumVersion &lt;System.Version&gt;</div><div class="wrappedParam">-CleanUp &lt;SwitchParameter&gt;</div><div class="wrappedParam">-SkipPublisherCheck &lt;SwitchParameter&gt;</div><div class="wrappedParam">-Scope &lt;String&gt;</div><div class="wrappedParam">-AllowClobber &lt;SwitchParameter&gt;</div><div class="wrappedParam">-Proxy &lt;System.Uri&gt;</div><div class="wrappedParam">-ProxyCredential &lt;PSCredential&gt;</div><div class="wrappedParam">-Force &lt;SwitchParameter&gt;</div><div class="wrappedParam">-WhatIf &lt;SwitchParameter&gt;</div><div class="wrappedParam">-Confirm &lt;SwitchParameter&gt;</div></div></div></pre>
+                    <pre><div class="syntaxblock"><div class="cmdlet">Install-AWSToolsModule</div><div class="paramlist"><div class="wrappedParam">-Name &lt;String&gt;</div><div class="wrappedParam">-RequiredVersion &lt;System.Version&gt;</div><div class="wrappedParam">-MinimumVersion &lt;System.Version&gt;</div><div class="wrappedParam">-MaximumVersion &lt;System.Version&gt;</div><div class="wrappedParam">-CleanUp &lt;SwitchParameter&gt;</div><div class="wrappedParam">-SkipUpdate &lt;SwitchParameter&gt;</div><div class="wrappedParam">-SkipPublisherCheck &lt;SwitchParameter&gt;</div><div class="wrappedParam">-Scope &lt;String&gt;</div><div class="wrappedParam">-AllowClobber &lt;SwitchParameter&gt;</div><div class="wrappedParam">-Proxy &lt;System.Uri&gt;</div><div class="wrappedParam">-ProxyCredential &lt;PSCredential&gt;</div><div class="wrappedParam">-Force &lt;SwitchParameter&gt;</div><div class="wrappedParam">-WhatIf &lt;SwitchParameter&gt;</div><div class="wrappedParam">-Confirm &lt;SwitchParameter&gt;</div></div></div></pre>
                 </div>
             </div>
         </div>
@@ -95,7 +95,9 @@
                 </div>
             </div>
             <div class="sectionbody">
-                <div class="description">This cmdlet uses Install-Module to update all AWS.Tools modules.</div>
+                <div class="description">This cmdlet uses Install-Module to install AWS.Tools modules. Unless -SkipUpdate
+                    is specified, this cmdlet also updates all other currently installed AWS.Tools modules to the
+                    version being installed.</div>
             </div>
         </div>
         <div>
@@ -107,10 +109,32 @@
             <div class="sectionbody">
                 <div class="parameters">
                     <div class="parameter">
+                        <div class="parameterName">-Name &lt;<a
+                                href="https://docs.microsoft.com/en-us/dotnet/api/system.string"
+                                target="_blank" rel="noopener noreferrer">String[]</a>&gt;</div>
+                        <div class="parameterDescription">Specifies names of the AWS.Tools modules to install. The names can be listed either with or without the "AWS.Tools." prefix (i.e. "AWS.Tools.Common" or simply "Common").</div>
+                        <div class="parameterAttributes">
+                            <table>
+                                <tr>
+                                    <td class="col1">Required?</td>
+                                    <td class="col2">True</td>
+                                </tr>
+                                <tr>
+                                    <td class="col1">Position?</td>
+                                    <td class="col2">1</td>
+                                </tr>
+                                <tr>
+                                    <td class="col1">Accept pipeline input?</td>
+                                    <td class="col2">True (ByValue, ByPropertyName)</td>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="parameter">
                         <div class="parameterName">-RequiredVersion &lt;<a
                                 href="https://docs.microsoft.com/en-us/dotnet/api/system.version"
                                 target="_blank" rel="noopener noreferrer">Version</a>&gt;</div>
-                        <div class="parameterDescription">Specifies exact version number of the module to update to.</div>
+                        <div class="parameterDescription">Specifies exact version number of the module to install.</div>
                         <div class="parameterAttributes">
                             <table>
                                 <tr>
@@ -119,7 +143,29 @@
                                 </tr>
                                 <tr>
                                     <td class="col1">Position?</td>
-                                    <td class="col2">1</td>
+                                    <td class="col2">2</td>
+                                </tr>
+                                <tr>
+                                    <td class="col1">Accept pipeline input?</td>
+                                    <td class="col2">True (ByPropertyName)</td>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="parameter">
+                        <div class="parameterName">-MinimumVersion &lt;<a
+                                href="https://docs.microsoft.com/en-us/dotnet/api/system.version"
+                                target="_blank" rel="noopener noreferrer">Version</a>&gt;</div>
+                        <div class="parameterDescription">Specifies the minimum version of the modules to install.</div>
+                        <div class="parameterAttributes">
+                            <table>
+                                <tr>
+                                    <td class="col1">Required?</td>
+                                    <td class="col2">False</td>
+                                </tr>
+                                <tr>
+                                    <td class="col1">Position?</td>
+                                    <td class="col2">Named</td>
                                 </tr>
                                 <tr>
                                     <td class="col1">Accept pipeline input?</td>
@@ -132,7 +178,7 @@
                         <div class="parameterName">-MaximumVersion &lt;<a
                                 href="https://docs.microsoft.com/en-us/dotnet/api/system.version"
                                 target="_blank" rel="noopener noreferrer">Version</a>&gt;</div>
-                        <div class="parameterDescription">Specifies the maximum version of the modules to update to.</div>
+                        <div class="parameterDescription">Specifies the maximum version of the modules to install.</div>
                         <div class="parameterAttributes">
                             <table>
                                 <tr>
@@ -152,7 +198,29 @@
                     </div>
                     <div class="parameter">
                         <div class="parameterName">-CleanUp &lt;SwitchParameter&gt;</div>
-                        <div class="parameterDescription">Specifies that, after a successful install, all other versions of the AWS Tools modules should be uninstalled.</div>
+                        <div class="parameterDescription">Specifies that, after a successful install, all other versions
+                            of the AWS Tools modules should be uninstalled.</div>
+                        <div class="parameterAttributes">
+                            <table>
+                                <tr>
+                                    <td class="col1">Required?</td>
+                                    <td class="col2">False</td>
+                                </tr>
+                                <tr>
+                                    <td class="col1">Position?</td>
+                                    <td class="col2">Named</td>
+                                </tr>
+                                <tr>
+                                    <td class="col1">Accept pipeline input?</td>
+                                    <td class="col2">True (ByPropertyName)</td>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="parameter">
+                        <div class="parameterName">-SkipUpdate &lt;SwitchParameter&gt;</div>
+                        <div class="parameterDescription">Install-AWSToolsModule by default also updates all currently
+                            installed AWS.Tools modules. -SkipUpdate disables the update.</div>
                         <div class="parameterAttributes">
                             <table>
                                 <tr>
@@ -194,7 +262,12 @@
                         <div class="parameterName">-Scope &lt;<a
                                 href="https://docs.microsoft.com/en-us/dotnet/api/system.string"
                                 target="_blank" rel="noopener noreferrer">String</a>&gt;</div>
-                        <div class="parameterDescription">Specifies the installation scope of the module. The acceptable values for this parameter are AllUsers and CurrentUser. The AllUsers scope installs modules in a location that is accessible to all users of the computer: $env:ProgramFiles\PowerShell\Modules. The CurrentUser installs modules in a location that is accessible only to the current user of the computer: $home\Documents\PowerShell\Modules. When no Scope is defined, the default is CurrentUser.</div>
+                        <div class="parameterDescription">Specifies the installation scope of the module. The acceptable
+                            values for this parameter are AllUsers and CurrentUser. The AllUsers scope installs modules
+                            in a location that is accessible to all users of the computer:
+                            $env:ProgramFiles\PowerShell\Modules The CurrentUser installs modules in a location that is
+                            accessible only to the current user of the computer: $home\Documents\PowerShell\Modules When
+                            no Scope is defined, the default is CurrentUser.</div>
                         <div class="parameterAttributes">
                             <table>
                                 <tr>
@@ -279,7 +352,8 @@
                     </div>
                     <div class="parameter">
                         <div class="parameterName">-Force &lt;SwitchParameter&gt;</div>
-                        <div class="parameterDescription">Forces an update of each specified module without a prompt to request confirmation.</div>
+                        <div class="parameterDescription">Forces an install of each specified module without a prompt to
+                            request confirmation.</div>
                         <div class="parameterAttributes">
                             <table>
                                 <tr>
@@ -295,6 +369,21 @@
                                     <td class="col2">True (ByPropertyName)</td>
                                 </tr>
                             </table>
+                        </div>
+                    </div>
+                </div>
+                <div>
+                    <div>
+                        <div class="collapsibleSection">
+                            <h2 id="inputs" class="title">Inputs</h2>
+                        </div>
+                    </div>
+                    <div class="sectionbody">
+                        <div class="inputs">
+                            <div class="inputType"><a href="https://docs.microsoft.com/en-us/dotnet/api/system.string"
+                                    target="_blank" rel="noopener noreferrer">System.String</a></div>
+                            <div class="inputDescription">You can pipe a String object to this cmdlet for the Name
+                                parameter.</div>
                         </div>
                     </div>
                 </div>
@@ -319,7 +408,7 @@
                 </div>
                 <div class="sectionbody">
                     <div class="examples">
-                        <h4>Example 1</h4><pre class="example"><div class="code">Update-AWSToolsModule -CleanUp</div><div class="description">This example updates all installed AWS.Tools modules to the latest version available on the PSGallery and uninstalls all other versions.</div></pre>
+                        <h4>Example 1</h4><pre class="example"><div class="code">Install-AWSToolsModule EC2,S3 -RequiredVersion 4.0.0.0</div><div class="description">This example installs version 4.0.0.0 of AWS.Tools.EC2, AWS.Tools.S3 and their dependencies.</div></pre>
                     </div>
                 </div>
             </div>
@@ -350,22 +439,22 @@
                 </div>
                 <div class="sectionbody">
                     <div class="versioninfo">
-                        <p><strong>AWS Tools for PowerShell: </strong><span id="assemblyVersion">2.x.y.z</span></p>
+                        <p><strong>AWS.Tools.Installer: </strong><span id="assemblyVersion">%INSTALLER_VERSION%</span></p>
                     </div>
                 </div>
             </div>
             <div id="pageFooter">
                 <span class="newline linkto"><a href="javascript:void(0)"
-                        onclick="AWSHelpObj.displayLink('Update-AWSToolsModule.html', 'Update-AWSToolsModule')">Link
+                        onclick="AWSHelpObj.displayLink('Install-AWSToolsModule.html', 'Install-AWSToolsModule')">Link
                         to this page</a></span>
                 <span class="divider">&nbsp;</span>
                 <!-- BEGIN-FEEDBACK-SECTION --><span class="feedback"><span class="feedbackLinks">
                         <!-- BEGIN-FEEDBACK-SECTION -->Did this page help you?&nbsp;&nbsp;<a
-                            href="http://docs.aws.amazon.com/powershell/v5/reference/feedbackyes.html?topic_id=Update-AWSToolsModule"
+                            href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackyes.html?topic_id=Install-AWSToolsModule"
                             target="_parent">Yes</a>&nbsp;&nbsp;<a
-                            href="http://docs.aws.amazon.com/powershell/v5/reference/feedbackno.html?topic_id=Update-AWSToolsModule"
+                            href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackno.html?topic_id=Install-AWSToolsModule"
                             target="_parent">No</a>&nbsp;&nbsp;&nbsp;<a
-                            href="https://docs.aws.amazon.com/forms/aws-doc-feedback?service_name=PowerShell-Ref&amp;topic_url=https://docs.aws.amazon.com/powershell/v5/reference/items/Update-AWSToolsModule.html"
+                            href="https://docs.aws.amazon.com/forms/aws-doc-feedback?service_name=PowerShell-Ref&amp;topic_url=https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/items/Install-AWSToolsModule.html"
                             target="_parent">Tell us about it...</a><!-- END-FEEDBACK-SECTION --></span></span>
                 <!-- END-FEEDBACK-SECTION -->
                 <div id="awsdocs-legal-zone-copyright"></div>
@@ -384,7 +473,6 @@ $("div#regionDisclaimer").css("display", "block");
 } else {
 $("div#regionDisclaimer").remove();
 }
-AWSHelpObj.setAssemblyVersion();
 AWSHelpObj.setCopyrightText();
 });
 </script>

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Installer_cmdlets.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Installer_cmdlets.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Installer Cmdlets">
 <title>Installation | AWS Tools for PowerShell</title>
 <script type="text/javascript" src="/assets/js/awsdocs-boot.js"></script>
-<link rel="canonical" href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/index.html?page=Installer_cmdlets.html&tocid=Installer_cmdlets"/>
+<link rel="canonical" href="http://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/index.html?page=Installer_cmdlets.html&tocid=Installer_cmdlets"/>
 </head>
 <body>
 <div id="product_name">AWS Tools for Windows PowerShell</div>
@@ -100,7 +100,7 @@ Updates all currently installed AWS.Tools modules.
 <div id="pageFooter">
 <span class="newline linkto"><a href="javascript:void(0)" onclick="AWSHelpObj.displayLink('Installer_cmdlets.html', 'Installer_cmdlets')">Link to this page</a></span>
 <span class="divider">&nbsp;</span>
-<!-- BEGIN-FEEDBACK-SECTION --><span class="feedback"><span class="feedbackLinks"><!-- BEGIN-FEEDBACK-SECTION -->Did this page help you?&nbsp;&nbsp;<a href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackyes.html?topic_id=Installer_cmdlets" target="_parent">Yes</a>&nbsp;&nbsp;<a href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackno.html?topic_id=Installer_cmdlets" target="_parent">No</a>&nbsp;&nbsp;&nbsp;<a href="https://docs.aws.amazon.com/forms/aws-doc-feedback?service_name=PowerShell-Ref&amp;topic_url=https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/items/Installer_cmdlets.html" target="_parent">Tell us about it...</a><!-- END-FEEDBACK-SECTION --></span></span><!-- END-FEEDBACK-SECTION -->
+<!-- BEGIN-FEEDBACK-SECTION --><span class="feedback"><span class="feedbackLinks"><!-- BEGIN-FEEDBACK-SECTION -->Did this page help you?&nbsp;&nbsp;<a href="http://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/feedbackyes.html?topic_id=Installer_cmdlets" target="_parent">Yes</a>&nbsp;&nbsp;<a href="http://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/feedbackno.html?topic_id=Installer_cmdlets" target="_parent">No</a>&nbsp;&nbsp;&nbsp;<a href="https://docs.aws.amazon.com/forms/aws-doc-feedback?service_name=PowerShell-Ref&amp;topic_url=https://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/items/Installer_cmdlets.html" target="_parent">Tell us about it...</a><!-- END-FEEDBACK-SECTION --></span></span><!-- END-FEEDBACK-SECTION -->
 <div id="awsdocs-legal-zone-copyright"></div>
 </div>
 <script type="text/javascript" src="../resources/jquery.min.js"></script>

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Installer_cmdlets.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Installer_cmdlets.html
@@ -1,0 +1,129 @@
+﻿<html>
+<head>
+<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+<meta name="guide-name" content="Cmdlet Reference"/>
+<meta name="service-name" content="AWS Tools for PowerShell"/>
+<link rel="stylesheet" type="text/css" href="../resources/style.css"/>
+<link rel="stylesheet" type="text/css" href="../resources/syntaxhighlighter/shCore.css">
+<link rel="stylesheet" type="text/css" href="../resources/syntaxhighlighter/shThemeDefault.css">
+<link rel="stylesheet" type="text/css" href="../resources/psstyle.css"/>
+<meta name="description" content="Installer Cmdlets">
+<title>Installation | AWS Tools for PowerShell</title>
+<script type="text/javascript" src="/assets/js/awsdocs-boot.js"></script>
+<link rel="canonical" href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/index.html?page=Installer_cmdlets.html&tocid=Installer_cmdlets"/>
+</head>
+<body>
+<div id="product_name">AWS Tools for Windows PowerShell</div>
+<div id="guide_name">Command Reference</div>
+<!--REGION_DISCLAIMER_DO_NOT_REMOVE-->
+<!-- BEGIN-SECTION -->
+<div id="regionDisclaimer">
+<p>AWS services or capabilities described in AWS Documentation may vary by region/location. Click <a href="https://docs.amazonaws.cn/en_us/aws/latest/userguide/services.html">Getting Started with Amazon AWS</a> to see specific differences applicable to the China (Beijing) Region.</p>
+</div>
+<!-- END-SECTION -->
+<div id="pageHeader">
+<div id="titles">
+<h1>AWS Tools for PowerShell - Installation</h1>
+<h2>Available in <a href="https://www.powershellgallery.com/packages/AWS.Tools.Installer/" target="_blank" rel="noopener noreferrer">AWS.Tools.Installer</a></h2>
+</div>
+</div>
+<div id="pageToolbar">
+<!-- BEGIN-SECTION -->
+<div id="search">
+<form action="/search/doc-search.html" target="_blank" onsubmit="return AWSHelpObj.searchFormSubmit(this);" method="get">
+<div id="sfrm">
+<span id="lbl">
+<label>Search: </label>
+</span>
+<select name="searchPath" id="sel">
+<option value="all">Entire Site</option>
+<option value="articles">Articles &amp; Tutorials</option>
+<option value="documentation">Documentation</option>
+<option value="documentation-product">Documentation - This Product</option>
+<option selected="" value="documentation-guide">Documentation - This Guide</option>
+<option value="releasenotes">Release Notes</option>
+<option value="code">Sample Code &amp; Libraries</option>
+</select>
+<input type="text" name="searchQuery" id="sq">
+<input type="image" alt="Go" src="../resources/search-button.png" id="sb">
+</div>
+<input id="this_doc_product" type="hidden" value="AWS Tools for Windows PowerShell" name="this_doc_product">
+<input id="this_doc_guide" type="hidden" value="Command Reference" name="this_doc_guide">
+<input type="hidden" value="en_us" name="doc_locale">
+</form>
+</div>
+<!-- END-SECTION -->
+</div>
+<div id="pageContent">
+<div>
+<div>
+<div class="collapsibleSection">
+<h2 id="cmdlets" class="title">Cmdlets</h2>
+</div>
+</div>
+<div class="sectionbody">
+<table class="members">
+<tbody>
+<tr>
+<th class="nameColumn">Name</th>
+<th class="descriptionColumn">Description</th>
+</tr>
+<tr>
+<td>
+<a href="./Install-AWSToolsModule.html">Install-AWSToolsModule</a>
+</td>
+<td>
+Installs AWS.Tools modules.
+</td>
+</tr>
+<tr>
+<td>
+<a href="./Uninstall-AWSToolsModule.html">Uninstall-AWSToolsModule</a>
+</td>
+<td>
+Uninstalls all currently installed AWS.Tools modules.
+</td>
+</tr>
+<tr>
+<td>
+<a href="./Update-AWSToolsModule.html">Update-AWSToolsModule</a>
+</td>
+<td>
+Updates all currently installed AWS.Tools modules.
+</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div id="pageFooter">
+<span class="newline linkto"><a href="javascript:void(0)" onclick="AWSHelpObj.displayLink('Installer_cmdlets.html', 'Installer_cmdlets')">Link to this page</a></span>
+<span class="divider">&nbsp;</span>
+<!-- BEGIN-FEEDBACK-SECTION --><span class="feedback"><span class="feedbackLinks"><!-- BEGIN-FEEDBACK-SECTION -->Did this page help you?&nbsp;&nbsp;<a href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackyes.html?topic_id=Installer_cmdlets" target="_parent">Yes</a>&nbsp;&nbsp;<a href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackno.html?topic_id=Installer_cmdlets" target="_parent">No</a>&nbsp;&nbsp;&nbsp;<a href="https://docs.aws.amazon.com/forms/aws-doc-feedback?service_name=PowerShell-Ref&amp;topic_url=https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/items/Installer_cmdlets.html" target="_parent">Tell us about it...</a><!-- END-FEEDBACK-SECTION --></span></span><!-- END-FEEDBACK-SECTION -->
+<div id="awsdocs-legal-zone-copyright"></div>
+</div>
+<script type="text/javascript" src="../resources/jquery.min.js"></script>
+<script type="text/javascript">jQuery.noConflict();</script>
+<script type="text/javascript" src="../resources/parseuri.js"></script>
+<script type="text/javascript" src="../resources/pagescript.js"></script>
+<!-- BEGIN-SECTION -->
+<script type="text/javascript">
+jQuery(function ($) {
+var host = parseUri($(window.parent.location).attr('href')).host;
+if (AWSHelpObj.showRegionalDisclaimer(host)) {
+$("div#regionDisclaimer").css("display", "block");
+} else {
+$("div#regionDisclaimer").remove();
+}
+AWSHelpObj.setCopyrightText();
+});
+</script>
+<!-- END-SECTION -->
+<script type="text/javascript" src="../resources/syntaxhighlighter/shCore.js"></script>
+<script type="text/javascript" src="../resources/syntaxhighlighter/shBrushCSharp.js"></script>
+<script type="text/javascript" src="../resources/syntaxhighlighter/shBrushPlain.js"></script>
+<script type="text/javascript" src="../resources/syntaxhighlighter/shBrushXml.js"></script>
+<script type="text/javascript">SyntaxHighlighter.all()</script>
+</body>
+</html>

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Uninstall-AWSToolsModule.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Uninstall-AWSToolsModule.html
@@ -12,7 +12,7 @@
     <title>AWS.Tools.Installer: Uninstall-AWSToolsModule Cmdlet | AWS Tools for PowerShell</title>
     <script type="text/javascript" src="/assets/js/awsdocs-boot.js"></script>
     <meta name="aws-tocid" content="Uninstall-AWSToolsModule"/>
-    <link rel="canonical" href="https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/items/Uninstall-AWSToolsModule.html"/>
+    <link rel="canonical" href="https://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/items/Uninstall-AWSToolsModule.html"/>
 </head>
 
 <body>
@@ -259,7 +259,7 @@
                 </div>
                 <div class="sectionbody">
                     <div class="versioninfo">
-                        <p><strong>AWS.Tools.Installer: </strong><span id="assemblyVersion">%INSTALLER_VERSION%</span></p>
+                        <p><strong>AWS.Tools.Installer: </strong><span id="assemblyVersion">{INSTALLER_VERSION}</span></p>
                     </div>
                 </div>
             </div>
@@ -270,11 +270,11 @@
                 <span class="divider">&nbsp;</span>
                 <!-- BEGIN-FEEDBACK-SECTION --><span class="feedback"><span class="feedbackLinks">
                         <!-- BEGIN-FEEDBACK-SECTION -->Did this page help you?&nbsp;&nbsp;<a
-                            href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackyes.html?topic_id=Uninstall-AWSToolsModule"
+                            href="http://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/feedbackyes.html?topic_id=Uninstall-AWSToolsModule"
                             target="_parent">Yes</a>&nbsp;&nbsp;<a
-                            href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackno.html?topic_id=Uninstall-AWSToolsModule"
+                            href="http://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/feedbackno.html?topic_id=Uninstall-AWSToolsModule"
                             target="_parent">No</a>&nbsp;&nbsp;&nbsp;<a
-                            href="https://docs.aws.amazon.com/forms/aws-doc-feedback?service_name=PowerShell-Ref&amp;topic_url=https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/items/Uninstall-AWSToolsModule.html"
+                            href="https://docs.aws.amazon.com/forms/aws-doc-feedback?service_name=PowerShell-Ref&amp;topic_url=https://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/items/Uninstall-AWSToolsModule.html"
                             target="_parent">Tell us about it...</a><!-- END-FEEDBACK-SECTION --></span></span>
                 <!-- END-FEEDBACK-SECTION -->
                 <div id="awsdocs-legal-zone-copyright"></div>

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Uninstall-AWSToolsModule.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Uninstall-AWSToolsModule.html
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -12,7 +12,7 @@
     <title>AWS.Tools.Installer: Uninstall-AWSToolsModule Cmdlet | AWS Tools for PowerShell</title>
     <script type="text/javascript" src="/assets/js/awsdocs-boot.js"></script>
     <meta name="aws-tocid" content="Uninstall-AWSToolsModule"/>
-    <link rel="canonical" href="https://docs.aws.amazon.com/powershell/v5/reference/items/Uninstall-AWSToolsModule.html"/>
+    <link rel="canonical" href="https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/items/Uninstall-AWSToolsModule.html"/>
 </head>
 
 <body>
@@ -259,7 +259,7 @@
                 </div>
                 <div class="sectionbody">
                     <div class="versioninfo">
-                        <p><strong>AWS Tools for PowerShell: </strong><span id="assemblyVersion">2.x.y.z</span></p>
+                        <p><strong>AWS.Tools.Installer: </strong><span id="assemblyVersion">%INSTALLER_VERSION%</span></p>
                     </div>
                 </div>
             </div>
@@ -270,11 +270,11 @@
                 <span class="divider">&nbsp;</span>
                 <!-- BEGIN-FEEDBACK-SECTION --><span class="feedback"><span class="feedbackLinks">
                         <!-- BEGIN-FEEDBACK-SECTION -->Did this page help you?&nbsp;&nbsp;<a
-                            href="http://docs.aws.amazon.com/powershell/v5/reference/feedbackyes.html?topic_id=Uninstall-AWSToolsModule"
+                            href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackyes.html?topic_id=Uninstall-AWSToolsModule"
                             target="_parent">Yes</a>&nbsp;&nbsp;<a
-                            href="http://docs.aws.amazon.com/powershell/v5/reference/feedbackno.html?topic_id=Uninstall-AWSToolsModule"
+                            href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackno.html?topic_id=Uninstall-AWSToolsModule"
                             target="_parent">No</a>&nbsp;&nbsp;&nbsp;<a
-                            href="https://docs.aws.amazon.com/forms/aws-doc-feedback?service_name=PowerShell-Ref&amp;topic_url=https://docs.aws.amazon.com/powershell/v5/reference/items/Uninstall-AWSToolsModule.html"
+                            href="https://docs.aws.amazon.com/forms/aws-doc-feedback?service_name=PowerShell-Ref&amp;topic_url=https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/items/Uninstall-AWSToolsModule.html"
                             target="_parent">Tell us about it...</a><!-- END-FEEDBACK-SECTION --></span></span>
                 <!-- END-FEEDBACK-SECTION -->
                 <div id="awsdocs-legal-zone-copyright"></div>
@@ -293,7 +293,6 @@ $("div#regionDisclaimer").css("display", "block");
 } else {
 $("div#regionDisclaimer").remove();
 }
-AWSHelpObj.setAssemblyVersion();
 AWSHelpObj.setCopyrightText();
 });
 </script>

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Update-AWSToolsModule.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Update-AWSToolsModule.html
@@ -12,7 +12,7 @@
     <title>AWS.Tools.Installer: Update-AWSToolsModule Cmdlet | AWS Tools for PowerShell</title>
     <script type="text/javascript" src="/assets/js/awsdocs-boot.js"></script>
     <meta name="aws-tocid" content="Update-AWSToolsModule"/>
-    <link rel="canonical" href="https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/items/Update-AWSToolsModule.html"/>
+    <link rel="canonical" href="https://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/items/Update-AWSToolsModule.html"/>
 </head>
 
 <body>
@@ -350,7 +350,7 @@
                 </div>
                 <div class="sectionbody">
                     <div class="versioninfo">
-                        <p><strong>AWS.Tools.Installer: </strong><span id="assemblyVersion">%INSTALLER_VERSION%</span></p>
+                        <p><strong>AWS.Tools.Installer: </strong><span id="assemblyVersion">{INSTALLER_VERSION}</span></p>
                     </div>
                 </div>
             </div>
@@ -361,11 +361,11 @@
                 <span class="divider">&nbsp;</span>
                 <!-- BEGIN-FEEDBACK-SECTION --><span class="feedback"><span class="feedbackLinks">
                         <!-- BEGIN-FEEDBACK-SECTION -->Did this page help you?&nbsp;&nbsp;<a
-                            href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackyes.html?topic_id=Update-AWSToolsModule"
+                            href="http://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/feedbackyes.html?topic_id=Update-AWSToolsModule"
                             target="_parent">Yes</a>&nbsp;&nbsp;<a
-                            href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackno.html?topic_id=Update-AWSToolsModule"
+                            href="http://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/feedbackno.html?topic_id=Update-AWSToolsModule"
                             target="_parent">No</a>&nbsp;&nbsp;&nbsp;<a
-                            href="https://docs.aws.amazon.com/forms/aws-doc-feedback?service_name=PowerShell-Ref&amp;topic_url=https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/items/Update-AWSToolsModule.html"
+                            href="https://docs.aws.amazon.com/forms/aws-doc-feedback?service_name=PowerShell-Ref&amp;topic_url=https://docs.aws.amazon.com/{INSTALLER_DOCS_ROOT}/items/Update-AWSToolsModule.html"
                             target="_parent">Tell us about it...</a><!-- END-FEEDBACK-SECTION --></span></span>
                 <!-- END-FEEDBACK-SECTION -->
                 <div id="awsdocs-legal-zone-copyright"></div>

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Update-AWSToolsModule.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Update-AWSToolsModule.html
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -8,11 +8,11 @@
     <link rel="stylesheet" type="text/css" href="../resources/syntaxhighlighter/shCore.css">
     <link rel="stylesheet" type="text/css" href="../resources/syntaxhighlighter/shThemeDefault.css">
     <link rel="stylesheet" type="text/css" href="../resources/psstyle.css" />
-    <meta name="description" content="Install AWS.Tools modules.">
-    <title>AWS.Tools.Installer: Install-AWSToolsModule Cmdlet | AWS Tools for PowerShell</title>
+    <meta name="description" content="This cmdlet uses Install-Module to update all AWS.Tools modules.">
+    <title>AWS.Tools.Installer: Update-AWSToolsModule Cmdlet | AWS Tools for PowerShell</title>
     <script type="text/javascript" src="/assets/js/awsdocs-boot.js"></script>
-    <meta name="aws-tocid" content="Install-AWSToolsModule"/>
-    <link rel="canonical" href="https://docs.aws.amazon.com/powershell/v5/reference/items/Install-AWSToolsModule.html"/>
+    <meta name="aws-tocid" content="Update-AWSToolsModule"/>
+    <link rel="canonical" href="https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/items/Update-AWSToolsModule.html"/>
 </head>
 
 <body>
@@ -28,7 +28,7 @@
     <!-- END-SECTION -->
     <div id="pageHeader">
         <div id="titles">
-            <h1>Install-AWSToolsModule Cmdlet</h1>
+            <h1>Update-AWSToolsModule Cmdlet</h1>
             <h2>
                 <div>Available in <a
                         href="https://www.powershellgallery.com/packages/AWS.Tools.Installer/"
@@ -73,7 +73,7 @@
                 </div>
             </div>
             <div class="sectionbody">
-                <div class="synopsis">Installs AWS.Tools modules.</div>
+                <div class="synopsis">Updates all currently installed AWS.Tools modules.</div>
             </div>
         </div>
         <div>
@@ -84,7 +84,7 @@
             </div>
             <div class="sectionbody">
                 <div class="syntax">
-                    <pre><div class="syntaxblock"><div class="cmdlet">Install-AWSToolsModule</div><div class="paramlist"><div class="wrappedParam">-Name &lt;String&gt;</div><div class="wrappedParam">-RequiredVersion &lt;System.Version&gt;</div><div class="wrappedParam">-MinimumVersion &lt;System.Version&gt;</div><div class="wrappedParam">-MaximumVersion &lt;System.Version&gt;</div><div class="wrappedParam">-CleanUp &lt;SwitchParameter&gt;</div><div class="wrappedParam">-SkipUpdate &lt;SwitchParameter&gt;</div><div class="wrappedParam">-SkipPublisherCheck &lt;SwitchParameter&gt;</div><div class="wrappedParam">-Scope &lt;String&gt;</div><div class="wrappedParam">-AllowClobber &lt;SwitchParameter&gt;</div><div class="wrappedParam">-Proxy &lt;System.Uri&gt;</div><div class="wrappedParam">-ProxyCredential &lt;PSCredential&gt;</div><div class="wrappedParam">-Force &lt;SwitchParameter&gt;</div><div class="wrappedParam">-WhatIf &lt;SwitchParameter&gt;</div><div class="wrappedParam">-Confirm &lt;SwitchParameter&gt;</div></div></div></pre>
+                    <pre><div class="syntaxblock"><div class="cmdlet">Update-AWSToolsModule</div><div class="paramlist"><div class="wrappedParam">-RequiredVersion &lt;System.Version&gt;</div><div class="wrappedParam">-MaximumVersion &lt;System.Version&gt;</div><div class="wrappedParam">-CleanUp &lt;SwitchParameter&gt;</div><div class="wrappedParam">-SkipPublisherCheck &lt;SwitchParameter&gt;</div><div class="wrappedParam">-Scope &lt;String&gt;</div><div class="wrappedParam">-AllowClobber &lt;SwitchParameter&gt;</div><div class="wrappedParam">-Proxy &lt;System.Uri&gt;</div><div class="wrappedParam">-ProxyCredential &lt;PSCredential&gt;</div><div class="wrappedParam">-Force &lt;SwitchParameter&gt;</div><div class="wrappedParam">-WhatIf &lt;SwitchParameter&gt;</div><div class="wrappedParam">-Confirm &lt;SwitchParameter&gt;</div></div></div></pre>
                 </div>
             </div>
         </div>
@@ -95,9 +95,7 @@
                 </div>
             </div>
             <div class="sectionbody">
-                <div class="description">This cmdlet uses Install-Module to install AWS.Tools modules. Unless -SkipUpdate
-                    is specified, this cmdlet also updates all other currently installed AWS.Tools modules to the
-                    version being installed.</div>
+                <div class="description">This cmdlet uses Install-Module to update all AWS.Tools modules.</div>
             </div>
         </div>
         <div>
@@ -109,63 +107,19 @@
             <div class="sectionbody">
                 <div class="parameters">
                     <div class="parameter">
-                        <div class="parameterName">-Name &lt;<a
-                                href="https://docs.microsoft.com/en-us/dotnet/api/system.string"
-                                target="_blank" rel="noopener noreferrer">String[]</a>&gt;</div>
-                        <div class="parameterDescription">Specifies names of the AWS.Tools modules to install. The names can be listed either with or without the "AWS.Tools." prefix (i.e. "AWS.Tools.Common" or simply "Common").</div>
+                        <div class="parameterName">-RequiredVersion &lt;<a
+                                href="https://docs.microsoft.com/en-us/dotnet/api/system.version"
+                                target="_blank" rel="noopener noreferrer">Version</a>&gt;</div>
+                        <div class="parameterDescription">Specifies exact version number of the module to update to.</div>
                         <div class="parameterAttributes">
                             <table>
                                 <tr>
                                     <td class="col1">Required?</td>
-                                    <td class="col2">True</td>
+                                    <td class="col2">False</td>
                                 </tr>
                                 <tr>
                                     <td class="col1">Position?</td>
                                     <td class="col2">1</td>
-                                </tr>
-                                <tr>
-                                    <td class="col1">Accept pipeline input?</td>
-                                    <td class="col2">True (ByValue, ByPropertyName)</td>
-                                </tr>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="parameter">
-                        <div class="parameterName">-RequiredVersion &lt;<a
-                                href="https://docs.microsoft.com/en-us/dotnet/api/system.version"
-                                target="_blank" rel="noopener noreferrer">Version</a>&gt;</div>
-                        <div class="parameterDescription">Specifies exact version number of the module to install.</div>
-                        <div class="parameterAttributes">
-                            <table>
-                                <tr>
-                                    <td class="col1">Required?</td>
-                                    <td class="col2">False</td>
-                                </tr>
-                                <tr>
-                                    <td class="col1">Position?</td>
-                                    <td class="col2">2</td>
-                                </tr>
-                                <tr>
-                                    <td class="col1">Accept pipeline input?</td>
-                                    <td class="col2">True (ByPropertyName)</td>
-                                </tr>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="parameter">
-                        <div class="parameterName">-MinimumVersion &lt;<a
-                                href="https://docs.microsoft.com/en-us/dotnet/api/system.version"
-                                target="_blank" rel="noopener noreferrer">Version</a>&gt;</div>
-                        <div class="parameterDescription">Specifies the minimum version of the modules to install.</div>
-                        <div class="parameterAttributes">
-                            <table>
-                                <tr>
-                                    <td class="col1">Required?</td>
-                                    <td class="col2">False</td>
-                                </tr>
-                                <tr>
-                                    <td class="col1">Position?</td>
-                                    <td class="col2">Named</td>
                                 </tr>
                                 <tr>
                                     <td class="col1">Accept pipeline input?</td>
@@ -178,7 +132,7 @@
                         <div class="parameterName">-MaximumVersion &lt;<a
                                 href="https://docs.microsoft.com/en-us/dotnet/api/system.version"
                                 target="_blank" rel="noopener noreferrer">Version</a>&gt;</div>
-                        <div class="parameterDescription">Specifies the maximum version of the modules to install.</div>
+                        <div class="parameterDescription">Specifies the maximum version of the modules to update to.</div>
                         <div class="parameterAttributes">
                             <table>
                                 <tr>
@@ -198,29 +152,7 @@
                     </div>
                     <div class="parameter">
                         <div class="parameterName">-CleanUp &lt;SwitchParameter&gt;</div>
-                        <div class="parameterDescription">Specifies that, after a successful install, all other versions
-                            of the AWS Tools modules should be uninstalled.</div>
-                        <div class="parameterAttributes">
-                            <table>
-                                <tr>
-                                    <td class="col1">Required?</td>
-                                    <td class="col2">False</td>
-                                </tr>
-                                <tr>
-                                    <td class="col1">Position?</td>
-                                    <td class="col2">Named</td>
-                                </tr>
-                                <tr>
-                                    <td class="col1">Accept pipeline input?</td>
-                                    <td class="col2">True (ByPropertyName)</td>
-                                </tr>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="parameter">
-                        <div class="parameterName">-SkipUpdate &lt;SwitchParameter&gt;</div>
-                        <div class="parameterDescription">Install-AWSToolsModule by default also updates all currently
-                            installed AWS.Tools modules. -SkipUpdate disables the update.</div>
+                        <div class="parameterDescription">Specifies that, after a successful install, all other versions of the AWS Tools modules should be uninstalled.</div>
                         <div class="parameterAttributes">
                             <table>
                                 <tr>
@@ -262,12 +194,7 @@
                         <div class="parameterName">-Scope &lt;<a
                                 href="https://docs.microsoft.com/en-us/dotnet/api/system.string"
                                 target="_blank" rel="noopener noreferrer">String</a>&gt;</div>
-                        <div class="parameterDescription">Specifies the installation scope of the module. The acceptable
-                            values for this parameter are AllUsers and CurrentUser. The AllUsers scope installs modules
-                            in a location that is accessible to all users of the computer:
-                            $env:ProgramFiles\PowerShell\Modules The CurrentUser installs modules in a location that is
-                            accessible only to the current user of the computer: $home\Documents\PowerShell\Modules When
-                            no Scope is defined, the default is CurrentUser.</div>
+                        <div class="parameterDescription">Specifies the installation scope of the module. The acceptable values for this parameter are AllUsers and CurrentUser. The AllUsers scope installs modules in a location that is accessible to all users of the computer: $env:ProgramFiles\PowerShell\Modules. The CurrentUser installs modules in a location that is accessible only to the current user of the computer: $home\Documents\PowerShell\Modules. When no Scope is defined, the default is CurrentUser.</div>
                         <div class="parameterAttributes">
                             <table>
                                 <tr>
@@ -352,8 +279,7 @@
                     </div>
                     <div class="parameter">
                         <div class="parameterName">-Force &lt;SwitchParameter&gt;</div>
-                        <div class="parameterDescription">Forces an install of each specified module without a prompt to
-                            request confirmation.</div>
+                        <div class="parameterDescription">Forces an update of each specified module without a prompt to request confirmation.</div>
                         <div class="parameterAttributes">
                             <table>
                                 <tr>
@@ -369,21 +295,6 @@
                                     <td class="col2">True (ByPropertyName)</td>
                                 </tr>
                             </table>
-                        </div>
-                    </div>
-                </div>
-                <div>
-                    <div>
-                        <div class="collapsibleSection">
-                            <h2 id="inputs" class="title">Inputs</h2>
-                        </div>
-                    </div>
-                    <div class="sectionbody">
-                        <div class="inputs">
-                            <div class="inputType"><a href="https://docs.microsoft.com/en-us/dotnet/api/system.string"
-                                    target="_blank" rel="noopener noreferrer">System.String</a></div>
-                            <div class="inputDescription">You can pipe a String object to this cmdlet for the Name
-                                parameter.</div>
                         </div>
                     </div>
                 </div>
@@ -408,7 +319,7 @@
                 </div>
                 <div class="sectionbody">
                     <div class="examples">
-                        <h4>Example 1</h4><pre class="example"><div class="code">Install-AWSToolsModule EC2,S3 -RequiredVersion 4.0.0.0</div><div class="description">This example installs version 4.0.0.0 of AWS.Tools.EC2, AWS.Tools.S3 and their dependencies.</div></pre>
+                        <h4>Example 1</h4><pre class="example"><div class="code">Update-AWSToolsModule -CleanUp</div><div class="description">This example updates all installed AWS.Tools modules to the latest version available on the PSGallery and uninstalls all other versions.</div></pre>
                     </div>
                 </div>
             </div>
@@ -439,22 +350,22 @@
                 </div>
                 <div class="sectionbody">
                     <div class="versioninfo">
-                        <p><strong>AWS Tools for PowerShell: </strong><span id="assemblyVersion">2.x.y.z</span></p>
+                        <p><strong>AWS.Tools.Installer: </strong><span id="assemblyVersion">%INSTALLER_VERSION%</span></p>
                     </div>
                 </div>
             </div>
             <div id="pageFooter">
                 <span class="newline linkto"><a href="javascript:void(0)"
-                        onclick="AWSHelpObj.displayLink('Install-AWSToolsModule.html', 'Install-AWSToolsModule')">Link
+                        onclick="AWSHelpObj.displayLink('Update-AWSToolsModule.html', 'Update-AWSToolsModule')">Link
                         to this page</a></span>
                 <span class="divider">&nbsp;</span>
                 <!-- BEGIN-FEEDBACK-SECTION --><span class="feedback"><span class="feedbackLinks">
                         <!-- BEGIN-FEEDBACK-SECTION -->Did this page help you?&nbsp;&nbsp;<a
-                            href="http://docs.aws.amazon.com/powershell/v5/reference/feedbackyes.html?topic_id=Install-AWSToolsModule"
+                            href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackyes.html?topic_id=Update-AWSToolsModule"
                             target="_parent">Yes</a>&nbsp;&nbsp;<a
-                            href="http://docs.aws.amazon.com/powershell/v5/reference/feedbackno.html?topic_id=Install-AWSToolsModule"
+                            href="http://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/feedbackno.html?topic_id=Update-AWSToolsModule"
                             target="_parent">No</a>&nbsp;&nbsp;&nbsp;<a
-                            href="https://docs.aws.amazon.com/forms/aws-doc-feedback?service_name=PowerShell-Ref&amp;topic_url=https://docs.aws.amazon.com/powershell/v5/reference/items/Install-AWSToolsModule.html"
+                            href="https://docs.aws.amazon.com/forms/aws-doc-feedback?service_name=PowerShell-Ref&amp;topic_url=https://docs.aws.amazon.com/%INSTALLER_DOCS_ROOT%/items/Update-AWSToolsModule.html"
                             target="_parent">Tell us about it...</a><!-- END-FEEDBACK-SECTION --></span></span>
                 <!-- END-FEEDBACK-SECTION -->
                 <div id="awsdocs-legal-zone-copyright"></div>
@@ -473,7 +384,6 @@ $("div#regionDisclaimer").css("display", "block");
 } else {
 $("div#regionDisclaimer").remove();
 }
-AWSHelpObj.setAssemblyVersion();
 AWSHelpObj.setCopyrightText();
 });
 </script>

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/StaticContent/package.redirects.conf
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/StaticContent/package.redirects.conf
@@ -1,3 +1,14 @@
+# AWS.Tools.Installer cmdlet reference moved out of the shared AWS Tools for PowerShell
+# reference tree into its own version-specific subtree (/powershell/installer/v1/reference/)
+# so installer major versions can coexist. Redirect the old v4/v5 URLs so existing links
+# and search results continue to resolve.
+RewriteRule ^/powershell/v4/reference/items/Install-AWSToolsModule.html /powershell/installer/v1/reference/items/Install-AWSToolsModule.html [L,R=301,NE]
+RewriteRule ^/powershell/v4/reference/items/Update-AWSToolsModule.html /powershell/installer/v1/reference/items/Update-AWSToolsModule.html [L,R=301,NE]
+RewriteRule ^/powershell/v4/reference/items/Uninstall-AWSToolsModule.html /powershell/installer/v1/reference/items/Uninstall-AWSToolsModule.html [L,R=301,NE]
+RewriteRule ^/powershell/v5/reference/items/Install-AWSToolsModule.html /powershell/installer/v1/reference/items/Install-AWSToolsModule.html [L,R=301,NE]
+RewriteRule ^/powershell/v5/reference/items/Update-AWSToolsModule.html /powershell/installer/v1/reference/items/Update-AWSToolsModule.html [L,R=301,NE]
+RewriteRule ^/powershell/v5/reference/items/Uninstall-AWSToolsModule.html /powershell/installer/v1/reference/items/Uninstall-AWSToolsModule.html [L,R=301,NE]
+
 RewriteRule ^/powershell/latest/reference(.*) /powershell/v5/reference$1 [L,R=301,NE]
 RewriteRule ^/powershell/v5/reference/Index.html /powershell/v5/reference/index.html [L,R=301,NE]
 RewriteRule ^/powershell/v5/reference/items/pstoolsref-commonparams.html /powershell/v5/reference/index.html [L,R]

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/StaticContent/package.redirects.conf
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/StaticContent/package.redirects.conf
@@ -8,6 +8,8 @@ RewriteRule ^/powershell/v4/reference/items/Uninstall-AWSToolsModule.html /power
 RewriteRule ^/powershell/v5/reference/items/Install-AWSToolsModule.html /powershell/installer/v1/reference/items/Install-AWSToolsModule.html [L,R=301,NE]
 RewriteRule ^/powershell/v5/reference/items/Update-AWSToolsModule.html /powershell/installer/v1/reference/items/Update-AWSToolsModule.html [L,R=301,NE]
 RewriteRule ^/powershell/v5/reference/items/Uninstall-AWSToolsModule.html /powershell/installer/v1/reference/items/Uninstall-AWSToolsModule.html [L,R=301,NE]
+RewriteRule ^/powershell/v4/reference/items/Installer_cmdlets.html /powershell/installer/v1/reference/items/Installer_cmdlets.html [L,R=301,NE]
+RewriteRule ^/powershell/v5/reference/items/Installer_cmdlets.html /powershell/installer/v1/reference/items/Installer_cmdlets.html [L,R=301,NE]
 
 RewriteRule ^/powershell/latest/reference(.*) /powershell/v5/reference$1 [L,R=301,NE]
 RewriteRule ^/powershell/v5/reference/Index.html /powershell/v5/reference/index.html [L,R=301,NE]

--- a/generator/AWSPSGeneratorLib/Properties/AssemblyInfo.cs
+++ b/generator/AWSPSGeneratorLib/Properties/AssemblyInfo.cs
@@ -19,6 +19,9 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
+// Expose internal members to the unit test assembly.
+[assembly: InternalsVisibleTo("AWSPSGeneratorLibTests")]
+
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1f8b12b6-2b75-4925-9869-e111232f8f4f")]
 

--- a/generator/AWSPSGeneratorLib/Writers/Help/TOCWriter.cs
+++ b/generator/AWSPSGeneratorLib/Writers/Help/TOCWriter.cs
@@ -41,10 +41,12 @@ namespace AWSPowerShellGenerator.Writers.Help
 
         public void AddFixedSection()
         {
-            //This should be replaced with proper help generation for script cmdlets
-            AddServiceCmdlet(InstallerModuleName, InstallerTOCName, "Install-AWSToolsModule", "Install-AWSToolsModule", "Installs AWS.Tools modules.", null);
-            AddServiceCmdlet(InstallerModuleName, InstallerTOCName, "Uninstall-AWSToolsModule", "Uninstall-AWSToolsModule", "Uninstalls all currently installed AWS.Tools modules.", null);
-            AddServiceCmdlet(InstallerModuleName, InstallerTOCName, "Update-AWSToolsModule", "Update-AWSToolsModule", "Updates all currently installed AWS.Tools modules.", null);
+            // AWS.Tools.Installer cmdlet reference is published to its own version-specific
+            // documentation subtree (/powershell/installer/v{majorVersion}/reference/) so that
+            // successive installer major versions can coexist independently of the AWS Tools for
+            // PowerShell version line. That self-contained subtree (its own frameset, TOC and
+            // pages) is emitted by WebHelpGenerator.WriteInstallerWebHelp(), so the installer
+            // cmdlets are intentionally not added to this (main AWS Tools) TOC.
         }
 
         // target page is synthesized from the cmdlet name once we emit the overall TOC; we will also

--- a/generator/AWSPSGeneratorLibTests/InstallerWebHelpTests.cs
+++ b/generator/AWSPSGeneratorLibTests/InstallerWebHelpTests.cs
@@ -1,0 +1,75 @@
+using AWSPowerShellGenerator.Generators;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AWSPSGeneratorLibTests
+{
+    /// <summary>
+    /// Locks in the installer-docs versioning contract: the AWS.Tools.Installer reference docs
+    /// are published to /powershell/installer/v{majorVersion}/reference/, where the version is
+    /// read from the installer module manifest. These tests guard the parsing/derivation that
+    /// makes the same implementation publish V1 today and V2 (once feature/installer-v2 merges)
+    /// automatically, with no code change.
+    /// </summary>
+    [TestClass]
+    public class InstallerWebHelpTests
+    {
+        [TestMethod]
+        public void ExtractModuleVersion_ReadsTopLevelModuleVersion()
+        {
+            // Representative of modules/Installer/AWS.Tools.Installer.psd1 on mainline (V1).
+            var manifest =
+                "@{\r\n" +
+                "    RootModule = 'AWS.Tools.Installer.psm1'\r\n" +
+                "    ModuleVersion = '1.0.3'\r\n" +
+                "}\r\n";
+
+            Assert.AreEqual("1.0.3", WebHelpGenerator.ExtractModuleVersion(manifest));
+        }
+
+        [TestMethod]
+        public void ExtractModuleVersion_PrefersTopLevelOverNestedRequiredModuleVersion()
+        {
+            // The manifest also contains a nested ModuleVersion inside RequiredModules; the
+            // top-level declaration precedes it and must win.
+            var manifest =
+                "@{\r\n" +
+                "    ModuleVersion = '1.0.3'\r\n" +
+                "    RequiredModules = @(\r\n" +
+                "        @{\r\n" +
+                "            ModuleName = 'PowerShellGet';\r\n" +
+                "            ModuleVersion = '2.2.1' }\r\n" +
+                "    )\r\n" +
+                "}\r\n";
+
+            Assert.AreEqual("1.0.3", WebHelpGenerator.ExtractModuleVersion(manifest));
+        }
+
+        [TestMethod]
+        public void ExtractModuleVersion_ReadsV2Manifest()
+        {
+            // feature/installer-v2 sets ModuleVersion = '2.0.1'; the same code must pick it up so
+            // docs publish to installer/v2/reference/ on merge.
+            var manifest = "@{\r\n    ModuleVersion = '2.0.1'\r\n}\r\n";
+
+            Assert.AreEqual("2.0.1", WebHelpGenerator.ExtractModuleVersion(manifest));
+        }
+
+        [TestMethod]
+        public void ExtractModuleVersion_ReturnsNullWhenMissingOrEmpty()
+        {
+            Assert.IsNull(WebHelpGenerator.ExtractModuleVersion("@{ RootModule = 'x.psm1' }"));
+            Assert.IsNull(WebHelpGenerator.ExtractModuleVersion(""));
+            Assert.IsNull(WebHelpGenerator.ExtractModuleVersion(null));
+        }
+
+        [TestMethod]
+        public void GetInstallerMajorVersion_DerivesMajorSegment()
+        {
+            Assert.AreEqual("1", WebHelpGenerator.GetInstallerMajorVersion("1.0.3"));
+            Assert.AreEqual("2", WebHelpGenerator.GetInstallerMajorVersion("2.0.1"));
+            Assert.AreEqual("10", WebHelpGenerator.GetInstallerMajorVersion("10.2.0.0"));
+            Assert.AreEqual(WebHelpGenerator.DefaultInstallerVersion.Split('.')[0],
+                WebHelpGenerator.GetInstallerMajorVersion(WebHelpGenerator.DefaultInstallerVersion));
+        }
+    }
+}

--- a/generator/AWSPSGeneratorLibTests/InstallerWebHelpTests.cs
+++ b/generator/AWSPSGeneratorLibTests/InstallerWebHelpTests.cs
@@ -1,4 +1,4 @@
-using AWSPowerShellGenerator.Generators;
+﻿using AWSPowerShellGenerator.Generators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace AWSPSGeneratorLibTests


### PR DESCRIPTION
## Rev 2 — review feedback (afroz429)

  Addressed both items from the first-pass review (commit `bd22fb957f`):

  - **UTF-8 BOM (required):** Added the UTF-8 BOM to
    `generator/AWSPSGeneratorLibTests/InstallerWebHelpTests.cs` to match the
    `.cs` convention across the generator (65 of 72 sources carry the BOM). Diff
    is exactly the 3 BOM bytes — no content change.
  - **Token style (nit):** Renamed the installer substitution tokens
    `%INSTALLER_VERSION%` / `%INSTALLER_DOCS_ROOT%` →
    `{INSTALLER_VERSION}` / `{INSTALLER_DOCS_ROOT}` to follow the existing
    `{TOKEN}` pattern (`{TOC}`, `{LEGACY_ALIASES_SNIPPET}`,
    `{COMMON_PARAM_SNIPPET}`) rather than introduce a new `%TOKEN%` style.

  No behavior change — generated output is byte-for-byte identical.
  `InstallerWebHelpTests` 5/5 pass.

## Description

Give the AWS.Tools.Installer cmdlet reference docs their own version-specific URL, decoupled from the AWS Tools for PowerShell (v5) version line, so installer major versions can coexist.

- Move the three installer cmdlet pages (Install/Update/Uninstall-AWSToolsModule) out of the shared reference tree into a new self-contained `HelpMaterials/WebHelp/InstallerContent/` tree (own frameset `index.html`, `TOC.html`, `items/`, and the `Installer_cmdlets.html` summary), tokenized with `%INSTALLER_VERSION%` and `%INSTALLER_DOCS_ROOT%`.
- Add `WebHelpGenerator.WriteInstallerWebHelp()`: reads `ModuleVersion` from `modules/Installer/AWS.Tools.Installer.psd1`, derives `v{major}`, and emits `installer/v{major}/reference/` with the version and doc-root substituted plus a private copy of the shared resources. Because the version is read from the manifest, V1 today and V2 on merge both publish correctly with no code change.
- Render the installer module version in the "Supported Version" section (instead of the AWS Tools assembly version) and drop the `setAssemblyVersion()` JS call.
- Remove the installer cmdlets from the main AWS Tools TOC (they now have their own self-contained TOC).
- Add 301 redirects for the old `/powershell/v{4,5}/reference/items/*-AWSToolsModule.html` and `Installer_cmdlets.html` URLs to the new installer path.
- Preserve the UTF-8 BOM when writing substituted pages; add `InternalsVisibleTo` + MSTest coverage for the version-to-path contract.

A companion change in the PowerShell 5 Catapult CDK  repo relocates the `installer/` subtree to the `/powershell/` deploy root. That must merge before this is fully live. (CR-292493137)

## Motivation and Context

Installer cmdlet reference pages were published under `/powershell/v{4,5}/reference/`, a path keyed on the AWS Tools version rather than the installer's own version, so a future installer major version (V2) would overwrite the V1 pages. This gives the installer docs an independent, version-specific home.

Resolves PowerShell-636.

## Testing

Built the generator and generated the installer subtree locally; served over HTTP and validated the frameset, self-contained TOC, per-cmdlet pages, `Supported Version: AWS.Tools.Installer: 1.0.3`, canonical/feedback URLs on the installer path, favicon, BOM, redirects staged, and no leaked tokens. V2 spot check (pointing at a `2.0.1` manifest) emits `installer/v2/reference/` with `2.0.1`. `InstallerWebHelpTests` — 5/5 passed.

### Dry-run
- **Dry-run ID:** 1c086a21-21d9-4d63-a64e-0cd13fa27ad5
- **Status:**
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **Failed bypass reason:** N/A

## Breaking Changes Assessment

Not a breaking change. Existing `/powershell/v{4,5}/...` installer URLs 301-redirect to the new path, so external links keep working. No cmdlet behavior or public API changes. No senior-engineer sign-off required on that basis.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
We require a second engineer to validate the PR before merging
- [ ] My code builds in Gamma and passes backward compatibility validation (required)
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
