### PR TITLE
Add canonical path containment check to zip extraction

### DIFF
--- a/modules/Installer/AWS.Tools.Installer.Lib/ModuleInstaller.cs
+++ b/modules/Installer/AWS.Tools.Installer.Lib/ModuleInstaller.cs
@@ -311,6 +311,8 @@ namespace Amazon.PowerShell.Installer
         {
             var buffer = local.Buffer;
             var zip = local.Archive;
+            // Canonical target root; every resolved destination below must start with this.
+            var fullDestDir = Path.GetFullPath(targetPath + Path.DirectorySeparatorChar);
             // CreateDirectory is idempotent and cheap; cache the last directory we created so
             // that all entries under the same dir don't re-issue the syscall per file.
             string? lastDir = null;
@@ -343,7 +345,11 @@ namespace Amazon.PowerShell.Installer
 
                 // Convert to the host's separator for filesystem paths.
                 var rel = IsWindows ? fullName.Replace('/', '\\') : fullName;
-                var destPath = Path.Combine(targetPath, rel);
+                var destPath = Path.GetFullPath(Path.Combine(targetPath, rel));
+                // Reject any entry that resolves outside the target root.
+                if (!destPath.StartsWith(fullDestDir, StringComparison.Ordinal))
+                    throw new InvalidDataException(
+                        $"Zip entry '{entry.FullName}' resolves outside the target directory.");
                 var destDir = Path.GetDirectoryName(destPath);
                 if (!string.IsNullOrEmpty(destDir) && destDir != lastDir)
                 {

--- a/tests/dotnet/Installer.Tests/Fixtures.cs
+++ b/tests/dotnet/Installer.Tests/Fixtures.cs
@@ -123,6 +123,24 @@ namespace Amazon.PowerShell.Installer.Tests
             return zipPath;
         }
 
+        /// <summary>
+        /// Builds a zip containing the given raw entry names verbatim, each with placeholder
+        /// content. Used to feed malicious traversal paths to the extractor.
+        /// </summary>
+        public static string BuildZipWithRawEntries(string zipPath, params string[] entryNames)
+        {
+            if (File.Exists(zipPath)) File.Delete(zipPath);
+            using var fs = new FileStream(zipPath, FileMode.Create, FileAccess.Write);
+            using var zip = new ZipArchive(fs, ZipArchiveMode.Create);
+            foreach (var name in entryNames)
+            {
+                var entry = zip.CreateEntry(name, CompressionLevel.NoCompression);
+                using var w = new StreamWriter(entry.Open());
+                w.Write("payload");
+            }
+            return zipPath;
+        }
+
         public static string NewTempDir(string prefix)
         {
             var p = Path.Combine(Path.GetTempPath(), $"{prefix}-{Guid.NewGuid():N}");

--- a/tests/dotnet/Installer.Tests/ModuleInstallerTests.cs
+++ b/tests/dotnet/Installer.Tests/ModuleInstallerTests.cs
@@ -436,6 +436,39 @@ namespace Amazon.PowerShell.Installer.Tests
             }
         }
 
+        [Fact]
+        public void ExtractAndInstall_TraversalEntry_ThrowsAndWritesNothingOutsideTarget()
+        {
+            // A "..\.." entry must not let the extractor write above the target directory.
+            var zip = Fixtures.BuildZipWithRawEntries(Path.Combine(_tempRoot, "AWS.Tools.zip"),
+                "AWS.Tools.Common/../../evil.psd1");
+            var target = Path.Combine(_tempRoot, "modules");
+
+            var ex = Record.Exception(() => ModuleInstaller.ExtractAndInstall(zip, target, null, null));
+
+            Assert.IsType<InvalidDataException>(Unwrap(ex));
+            // The entry resolves to <_tempRoot>/evil.psd1 - assert it was never created.
+            Assert.False(File.Exists(Path.Combine(_tempRoot, "evil.psd1")));
+        }
+
+        [Theory]
+        [InlineData("AWS.Tools.Common/..\\..\\evil.psd1")]   // backslash traversal (PS 5.1 zips)
+        [InlineData("/etc/cron.d/evil")]                     // rooted (unix)
+        [InlineData("C:\\Windows\\System32\\evil.dll")]      // drive-letter rooted (Windows)
+        public void ExtractAndInstall_UnsafeEntry_Throws(string entryName)
+        {
+            var zip = Fixtures.BuildZipWithRawEntries(Path.Combine(_tempRoot, "AWS.Tools.zip"), entryName);
+            var target = Path.Combine(_tempRoot, "modules");
+
+            var ex = Record.Exception(() => ModuleInstaller.ExtractAndInstall(zip, target, null, null));
+
+            Assert.IsType<InvalidDataException>(Unwrap(ex));
+        }
+
+        // Parallel.ForEach wraps body exceptions in AggregateException.
+        private static Exception? Unwrap(Exception? ex) =>
+            ex is AggregateException agg ? agg.Flatten().InnerException : ex;
+
         // ----- DeleteDirectoriesParallel -----
 
         [Fact]


### PR DESCRIPTION
Add canonical path containment check to zip extraction

## Description
Adds a directory-containment check to the module extraction path in `ModuleInstaller.ExtractModule`. Each zip entry's destination is now resolved with `Path.GetFullPath` and must start with the resolved target directory, otherwise extraction throws `InvalidDataException`. The existing `IsUnsafeRelativePath` check is kept as a first-pass reject.

Files changed:
- `modules/Installer/AWS.Tools.Installer.Lib/ModuleInstaller.cs` - the check (3 lines + a hoisted target-root value).
- `tests/dotnet/Installer.Tests/Fixtures.cs` - `BuildZipWithRawEntries` helper to build a zip with arbitrary entry names.
- `tests/dotnet/Installer.Tests/ModuleInstallerTests.cs` - one test for a traversal entry that also asserts nothing is written outside the target, plus a 3-case theory for backslash-traversal, rooted, and drive-letter entries.

Targets `feature/installer-v2` (Installer V2 release branch, PR #427).

## Motivation and Context
CodeQL flagged a Zip Slip alert (cs/zipslip, alert 7) https://github.com/aws/aws-tools-for-powershell/pull/427#discussion_r3680124902 on the extraction path: a zip entry name flows into a file write without a canonicalization-based containment check. The public `Install-AWSToolsModule -SourceZipPath` parameter
accepts a local zip, so the input is not guaranteed to be an Amazon-produced archive. `Path.GetFullPath` + `StartsWith` is the check CodeQL recognizes and resolves entries that the string scan does not model (for example NTFS alternate data streams and reserved device names on Windows).

## Testing
Ran the full installer suite (C# xUnit + Pester) on Linux and Windows.

| Platform | Shell | C# | Pester |
|---|---|---|---|
| Linux | PowerShell 7.6 | 32 passed | 468 passed / 1 skipped |
| Windows | Windows PowerShell 5.1 | 32 passed | 463 passed / 6 skipped |
| Windows | PowerShell 7 | 32 passed | 468 passed / 1 skipped |

No failures. Skip counts differ because some Pester tests are conditional on the PowerShell edition. Windows runs were done in AWS CodeBuild.

Also exercised `Install-AWSToolsModule` and `Uninstall-AWSToolsModule` on both Windows shells, via `-SourceZipPath` (local zip) and via the default CloudFront download, installing and removing AWS.Tools.S3 and AWS.Tools.EC2.

### Dry-run
- **Dry-run ID:** 428b124a-ad7d-40b2-b060-a84ed94021e8
- **Status:**
  - [x] Pending
  - [ ] Completed successfully
  - [ ] Failed
- **Failed bypass reason:**

## Breaking Changes Assessment
Not a breaking change. For valid archives the check does not change behavior; all real entries in the current AWS.Tools.zip pass. It only adds a rejection for entries that resolve outside the target directory.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My code builds in Gamma and passes backward compatibility validation (required)
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## New/existing dependencies impact assessment, if applicable
No dependency changes.

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
