### PR TITLE
Add AWS.Tools.Installer V2 GA changelog entry

### DIFF
--- a/changelogs/CHANGELOG.2026.md
+++ b/changelogs/CHANGELOG.2026.md
@@ -28,6 +28,56 @@
   * Amazon WorkSpaces
     * Modified cmdlet Edit-WKSClientProperty: added parameter ClientProperties_ClientExperiencePolicy.
 
+### AWS.Tools.Installer 2.0.2 (2026-08-04 21:56Z)
+  * **[GENERAL AVAILABILITY]** AWS.Tools.Installer V2 is now generally available. V2 introduces a major architectural redesign to installation performance and reliability, downloading a single zip file and extracting modules in parallel.
+  
+  * **New Cmdlets**
+    * Added cmdlet Install-AWSToolsInstaller for installing/updating the installer module itself
+    * Added cmdlet Uninstall-AWSToolsInstaller for removing the installer module
+  
+  * **Enhanced Security**
+    * Implemented SHA512 hash validation for all downloads by default
+    * Added -SkipIntegrityCheck parameter to bypass validation when needed
+    * Added -SourceHashPath parameter for local hash file validation in offline scenarios
+  
+  * **Improved Version Management**
+    * Added support for installing prerelease versions of AWS Tools for PowerShell and AWS Tools Installer
+    * Added support for installing latest major versions using wildcard patterns (e.g., "4.*" installs latest 4.x version)
+    * Restored -MinimumVersion and -MaximumVersion parameters for backward compatibility (marked as deprecated)
+    * Enhanced version resolution with better error messages and validation
+  
+  * **Offline Installation Support**
+    * Enhanced -SourceZipPath parameter to support local AWS.Tools.zip files for air-gapped environments
+    * Added local hash file validation via -SourceHashPath parameter
+  
+  * **Alternative V1 Cmdlets**
+    * Added V1 compatibility cmdlets (Install-AWSToolsModuleV1, Update-AWSToolsModuleV1, Uninstall-AWSToolsModuleV1) that maintain PowerShellGallery-based behavior for scripts that require it
+    * V1 cmdlets display deprecation warnings and will be removed in next major version
+  
+  * **Breaking Changes**
+    * Install-AWSToolsModule now installs all modules by default when -Name parameter is not specified
+    * Removed proxy support (-Proxy and -ProxyCredential parameters); workloads behind proxies should configure session proxy settings
+    * Deprecated parameters: -SkipUpdate, -SkipPublisherCheck, -AllowClobber (ignored in V2, will be removed in V3)
+  
+  * **Module Source**
+    * Changed module source from PowerShellGallery to CloudFront-hosted AWS.Tools.zip
+  
+  * **PowerShellGet Compatibility**
+    * Modules installed by AWS.Tools.Installer can now be removed with Uninstall-Module and Uninstall-PSResource
+  
+  * **Additional Improvements**
+    * Added automatic version check that warns when newer versions of AWS.Tools.Installer are available
+    * Added support for cleaning up legacy AWSPowerShell and AWSPowerShell.NetCore modules via -CleanUpLegacyModuleScope parameter
+    * Refactored codebase into modular function files for better maintainability
+    * Enhanced progress reporting with detailed status updates
+    * Improved error handling with retry logic and exponential backoff
+    * Added comprehensive unit test coverage
+    * Cross-platform compatibility improvements for Windows, Linux, and macOS
+  
+  * **Documentation**
+    * For detailed information about V2, see: https://aws.amazon.com/blogs/developer/aws-tools-installer-v2-is-now-generally-available/
+    * For migration guidance and feedback, see: https://github.com/aws/aws-tools-for-powershell/issues/411
+
 ### 5.0.268 (2026-08-03 19:25Z)
   * AWS Tools for PowerShell now use AWS .NET SDK 4.0.303.0 and leverage its new features and improvements. Please find a description of the changes at https://github.com/aws/aws-sdk-net/blob/main/changelogs/SDK.CHANGELOG.ALL.md.
   * Amazon CloudWatch Observability Admin Service

--- a/changelogs/CHANGELOG.ALL.md
+++ b/changelogs/CHANGELOG.ALL.md
@@ -28,6 +28,56 @@
   * Amazon WorkSpaces
     * Modified cmdlet Edit-WKSClientProperty: added parameter ClientProperties_ClientExperiencePolicy.
 
+### AWS.Tools.Installer 2.0.2 (2026-08-04 21:56Z)
+  * **[GENERAL AVAILABILITY]** AWS.Tools.Installer V2 is now generally available. V2 introduces a major architectural redesign to installation performance and reliability, downloading a single zip file and extracting modules in parallel.
+  
+  * **New Cmdlets**
+    * Added cmdlet Install-AWSToolsInstaller for installing/updating the installer module itself
+    * Added cmdlet Uninstall-AWSToolsInstaller for removing the installer module
+  
+  * **Enhanced Security**
+    * Implemented SHA512 hash validation for all downloads by default
+    * Added -SkipIntegrityCheck parameter to bypass validation when needed
+    * Added -SourceHashPath parameter for local hash file validation in offline scenarios
+  
+  * **Improved Version Management**
+    * Added support for installing prerelease versions of AWS Tools for PowerShell and AWS Tools Installer
+    * Added support for installing latest major versions using wildcard patterns (e.g., "4.*" installs latest 4.x version)
+    * Restored -MinimumVersion and -MaximumVersion parameters for backward compatibility (marked as deprecated)
+    * Enhanced version resolution with better error messages and validation
+  
+  * **Offline Installation Support**
+    * Enhanced -SourceZipPath parameter to support local AWS.Tools.zip files for air-gapped environments
+    * Added local hash file validation via -SourceHashPath parameter
+  
+  * **Alternative V1 Cmdlets**
+    * Added V1 compatibility cmdlets (Install-AWSToolsModuleV1, Update-AWSToolsModuleV1, Uninstall-AWSToolsModuleV1) that maintain PowerShellGallery-based behavior for scripts that require it
+    * V1 cmdlets display deprecation warnings and will be removed in next major version
+  
+  * **Breaking Changes**
+    * Install-AWSToolsModule now installs all modules by default when -Name parameter is not specified
+    * Removed proxy support (-Proxy and -ProxyCredential parameters); workloads behind proxies should configure session proxy settings
+    * Deprecated parameters: -SkipUpdate, -SkipPublisherCheck, -AllowClobber (ignored in V2, will be removed in V3)
+  
+  * **Module Source**
+    * Changed module source from PowerShellGallery to CloudFront-hosted AWS.Tools.zip
+  
+  * **PowerShellGet Compatibility**
+    * Modules installed by AWS.Tools.Installer can now be removed with Uninstall-Module and Uninstall-PSResource
+  
+  * **Additional Improvements**
+    * Added automatic version check that warns when newer versions of AWS.Tools.Installer are available
+    * Added support for cleaning up legacy AWSPowerShell and AWSPowerShell.NetCore modules via -CleanUpLegacyModuleScope parameter
+    * Refactored codebase into modular function files for better maintainability
+    * Enhanced progress reporting with detailed status updates
+    * Improved error handling with retry logic and exponential backoff
+    * Added comprehensive unit test coverage
+    * Cross-platform compatibility improvements for Windows, Linux, and macOS
+  
+  * **Documentation**
+    * For detailed information about V2, see: https://aws.amazon.com/blogs/developer/aws-tools-installer-v2-is-now-generally-available/
+    * For migration guidance and feedback, see: https://github.com/aws/aws-tools-for-powershell/issues/411
+
 ### 5.0.268 (2026-08-03 19:25Z)
   * AWS Tools for PowerShell now use AWS .NET SDK 4.0.303.0 and leverage its new features and improvements. Please find a description of the changes at https://github.com/aws/aws-sdk-net/blob/main/changelogs/SDK.CHANGELOG.ALL.md.
   * Amazon CloudWatch Observability Admin Service


### PR DESCRIPTION
## Description
Adds a general-availability changelog entry for AWS.Tools.Installer V2 to both `changelogs/CHANGELOG.ALL.md` and `changelogs/CHANGELOG.2026.md`. The entry mirrors the existing preview entry's content, reframed for GA. It is placed directly below the same-day AWS Tools for PowerShell release so the newest module release remains at the top of the file, matching the existing installer-entry placement convention.

## Motivation and Context
AWS.Tools.Installer V2 is now generally available. The changelog needs a GA entry documenting the V2 changes (new cmdlets, enhanced security, version management, offline install, V1 compatibility cmdlets, breaking changes, and the CloudFront-hosted module source) with a link to the GA announcement blog post.

## Testing
Documentation-only change. Verified:
- Both changelog files have byte-identical GA entries.
- The UTF-8 BOM and existing CRLF line endings are preserved (no line-ending churn — diff is purely the added lines).
- The entry is positioned below the newest numeric module release and above the preceding release, consistent with how the preview entry was placed.

### Dry-run
- **Dry-run ID:** 7964631e-fdb1-45b3-adca-01dde30022ad
- **Status:**
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **Failed bypass reason:**

## Breaking Changes Assessment
Not applicable — this is a documentation-only changelog addition with no code changes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
We require a second engineer to validate the PR before merging
- [ ] My code builds in Gamma and passes backward compatibility validation (required)
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-tools-for-powershell/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
