### PR TITLE
Warn when -Cleanup is skipped because installation was skipped (AWS.Tools.Installer 2.0.4)

### DIFF
--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Install-AWSToolsInstaller.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Install-AWSToolsInstaller.html
@@ -140,7 +140,10 @@
                     <div class="parameter">
                         <div class="parameterName">-Cleanup &lt;SwitchParameter&gt;</div>
                         <div class="parameterDescription">Removes previous versions of the installer after successful
-                            installation. By default, previous versions are preserved.</div>
+                            installation. By default, previous versions are preserved.<br /><br />
+                            Note: cleanup runs only as part of an installation. If installation is skipped because the
+                            requested version is already installed, cleanup is skipped as well and a warning is emitted.
+                            Use -Force to reinstall and clean up other installed versions.</div>
                         <div class="parameterAttributes">
                             <table>
                                 <tr>

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Install-AWSToolsModule.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Install-AWSToolsModule.html
@@ -204,7 +204,10 @@
                                 target="_blank" rel="noopener noreferrer">String</a>&gt;</div>
                         <div class="parameterDescription">Runs a separate cleanup of all instances of AWSPowerShell and
                             AWSPowerShell.NetCore found in the specified scope. Warns on failure. The acceptable values
-                            for this parameter are AllUsers and CurrentUser.</div>
+                            for this parameter are AllUsers and CurrentUser.<br /><br />
+                            Note: like -Cleanup, this runs only as part of an installation. If installation is skipped
+                            because the requested version is already installed, legacy cleanup is skipped as well and a
+                            warning is emitted. Use -Force to reinstall and run the legacy cleanup.</div>
                         <div class="parameterAttributes">
                             <table>
                                 <tr>

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Install-AWSToolsModule.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Install-AWSToolsModule.html
@@ -177,7 +177,10 @@
                             modules after successful installation like when using <code>Uninstall-AWSToolsModule
                             -ExceptVersion ...</code>. Otherwise, by default, other versions remain installed.<br /><br />
                             When the Name parameter is specified, cleanup only affects the named modules. When Name is not
-                            specified, all AWS Tools modules (except installer) are cleaned up.</div>
+                            specified, all AWS Tools modules (except installer) are cleaned up.<br /><br />
+                            Note: cleanup runs only as part of an installation. If installation is skipped because the
+                            requested version is already installed, cleanup is skipped as well and a warning is emitted.
+                            Use -Force to reinstall and clean up other installed versions.</div>
                         <div class="parameterAttributes">
                             <table>
                                 <tr>

--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Update-AWSToolsModule.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Update-AWSToolsModule.html
@@ -150,7 +150,10 @@
                             modules after successful update like when using <code>Uninstall-AWSToolsModule -ExceptVersion
                             ...</code>. Otherwise, by default, other versions are preserved.<br /><br />
                             Please note that ALL AWS Tools modules (except installer) will be uninstalled even when only
-                            specific modules were updated.</div>
+                            specific modules were updated.<br /><br />
+                            Note: cleanup runs only as part of an installation. If the update is skipped because the
+                            requested version is already installed, cleanup is skipped as well and a warning is emitted.
+                            Use -Force to reinstall and clean up other installed versions.</div>
                         <div class="parameterAttributes">
                             <table>
                                 <tr>

--- a/modules/Installer/AWS.Tools.Installer.psd1
+++ b/modules/Installer/AWS.Tools.Installer.psd1
@@ -10,7 +10,7 @@
     CompatiblePSEditions = @('Core', 'Desktop')
 
     # Version number of this module.
-    ModuleVersion = '2.0.3'
+    ModuleVersion = '2.0.4'
 
     # ID used to uniquely identify this module
     GUID = '450031c1-9177-4fc1-9518-93166b1a926b'

--- a/modules/Installer/Public/Install-AWSToolsInstaller.ps1
+++ b/modules/Installer/Public/Install-AWSToolsInstaller.ps1
@@ -17,6 +17,10 @@
     Removes previous versions of the installer after successful installation.
     By default, previous versions are preserved.
 
+    Note: cleanup runs only as part of an installation. If installation is skipped because the
+    requested version is already installed, cleanup is skipped as well and a warning is emitted.
+    Use -Force to reinstall and clean up other installed versions.
+
 .Parameter Scope
     Specifies the installation scope of the module as well as scope for module cleanup.
     The acceptable values for this parameter are AllUsers and CurrentUser.
@@ -296,6 +300,9 @@ To suppress this warning, specify a version constraint. Alternatively, you can s
                         if ($installedVersionString -eq $targetVersionString) {
                             Write-Verbose ("[$($MyInvocation.MyCommand)] AWS.Tools.Installer version $targetVersionString already installed, skipping installation")
                             Write-Host "Skipped installation: AWS.Tools.Installer version $targetVersionToInstall already installed in $targetPath"
+                            if ($Cleanup) {
+                                Write-Warning ("Cleanup was skipped because installation was skipped (AWS.Tools.Installer is already at version $targetVersionToInstall). Cleanup runs only as part of an installation; re-run with -Force to reinstall and remove other installed versions.")
+                            }
                             return
                         }
                     }

--- a/modules/Installer/Public/Install-AWSToolsModule.ps1
+++ b/modules/Installer/Public/Install-AWSToolsModule.ps1
@@ -81,9 +81,13 @@
     Use -Force to reinstall and clean up other installed versions.
 
 .Parameter CleanUpLegacyModuleScope
-    Runs a separate cleanup of all instances of AWSPowerShell and AWSPowerShell.NetCore 
-    found in the specified scope. Warns on failure. The acceptable values for this 
+    Runs a separate cleanup of all instances of AWSPowerShell and AWSPowerShell.NetCore
+    found in the specified scope. Warns on failure. The acceptable values for this
     parameter are AllUsers and CurrentUser.
+
+    Note: like -Cleanup, this runs only as part of an installation. If installation is skipped
+    because the requested version is already installed, legacy cleanup is skipped as well and a
+    warning is emitted. Use -Force to reinstall and run the legacy cleanup.
 
 .Parameter Scope
     Specifies the installation scope of the module as well as scope for module cleanup.
@@ -655,6 +659,9 @@ To suppress this warning, specify a version constraint. Alternatively, you can s
                             if ($Cleanup) {
                                 Write-Warning ("Cleanup was skipped because installation was skipped (the requested AWS.Tools modules are already at version $targetVersionToInstall). Cleanup runs only as part of an installation; re-run with -Force to reinstall and remove other installed versions.")
                             }
+                            if ($CleanUpLegacyModuleScope) {
+                                Write-Warning ("Legacy module cleanup (-CleanUpLegacyModuleScope) was skipped because installation was skipped. Re-run with -Force to reinstall and clean up legacy AWSPowerShell modules.")
+                            }
                             return
                         }
                     }
@@ -671,6 +678,9 @@ To suppress this warning, specify a version constraint. Alternatively, you can s
                             Write-Host "Skipped installation: AWS.Tools.Common version $targetVersionToInstall already installed in $targetPath. Use -Force to overwrite or add missing modules."
                             if ($Cleanup) {
                                 Write-Warning ("Cleanup was skipped because installation was skipped (AWS.Tools is already at version $targetVersionToInstall). Cleanup runs only as part of an installation; re-run with -Force to reinstall and remove other installed versions.")
+                            }
+                            if ($CleanUpLegacyModuleScope) {
+                                Write-Warning ("Legacy module cleanup (-CleanUpLegacyModuleScope) was skipped because installation was skipped. Re-run with -Force to reinstall and clean up legacy AWSPowerShell modules.")
                             }
                             return
                         }

--- a/modules/Installer/Public/Install-AWSToolsModule.ps1
+++ b/modules/Installer/Public/Install-AWSToolsModule.ps1
@@ -73,8 +73,12 @@
     
     Otherwise, by default, other versions remain installed.
     
-    When the Name parameter is specified, cleanup only affects the named modules. When Name is not 
+    When the Name parameter is specified, cleanup only affects the named modules. When Name is not
     specified, all AWS Tools modules (except installer) are cleaned up.
+
+    Note: cleanup runs only as part of an installation. If installation is skipped because the
+    requested version is already installed, cleanup is skipped as well and a warning is emitted.
+    Use -Force to reinstall and clean up other installed versions.
 
 .Parameter CleanUpLegacyModuleScope
     Runs a separate cleanup of all instances of AWSPowerShell and AWSPowerShell.NetCore 
@@ -648,6 +652,9 @@ To suppress this warning, specify a version constraint. Alternatively, you can s
                         if ($allRequestedPresentAtTarget) {
                             Write-Verbose ("[$($MyInvocation.MyCommand)] All requested AWS Tools modules already installed at version $targetVersionString, skipping installation")
                             Write-Host "Skipped installation: requested AWS.Tools modules version $targetVersionToInstall already installed in $targetPath. Use -Force to reinstall."
+                            if ($Cleanup) {
+                                Write-Warning ("Cleanup was skipped because installation was skipped (the requested AWS.Tools modules are already at version $targetVersionToInstall). Cleanup runs only as part of an installation; re-run with -Force to reinstall and remove other installed versions.")
+                            }
                             return
                         }
                     }
@@ -662,6 +669,9 @@ To suppress this warning, specify a version constraint. Alternatively, you can s
                         if ($installedCommon -and $installedCommon.Version.ToString() -eq $targetVersionString) {
                             Write-Verbose ("[$($MyInvocation.MyCommand)] AWS Tools version $targetVersionString already installed, skipping installation")
                             Write-Host "Skipped installation: AWS.Tools.Common version $targetVersionToInstall already installed in $targetPath. Use -Force to overwrite or add missing modules."
+                            if ($Cleanup) {
+                                Write-Warning ("Cleanup was skipped because installation was skipped (AWS.Tools is already at version $targetVersionToInstall). Cleanup runs only as part of an installation; re-run with -Force to reinstall and remove other installed versions.")
+                            }
                             return
                         }
                     }

--- a/modules/Installer/Public/Update-AWSToolsModule.ps1
+++ b/modules/Installer/Public/Update-AWSToolsModule.ps1
@@ -53,8 +53,12 @@
     
     Otherwise, by default, other versions are preserved. 
     
-    Please note that ALL AWS Tools modules (except installer) will be uninstalled even when 
-    only specific modules were updated. 
+    Please note that ALL AWS Tools modules (except installer) will be uninstalled even when
+    only specific modules were updated.
+
+    Note: cleanup runs only as part of an installation. If the update is skipped because the
+    requested version is already installed, cleanup is skipped as well and a warning is emitted.
+    Use -Force to reinstall and clean up other installed versions.
 
 .Parameter CleanUpLegacyModuleScope
     Runs a separate cleanup of all instances of AWSPowerShell and AWSPowerShell.NetCore 

--- a/tests/Installer/AWS.Tools.Installer.Unit.Public.Install-AWSToolsInstaller.Tests.ps1
+++ b/tests/Installer/AWS.Tools.Installer.Unit.Public.Install-AWSToolsInstaller.Tests.ps1
@@ -185,7 +185,29 @@ InModuleScope AWS.Tools.Installer {
                 Should -Not -Invoke Resolve-AWSToolsZipSource
                 Should -Not -Invoke Install-AWSToolsModuleFromZip
             }
-            
+
+            It "Should skip cleanup and warn to use -Force when -Cleanup is specified but the installer is already installed" {
+                # Option A: cleanup runs only as part of an install. When install is skipped
+                # (installer already at target), cleanup is skipped too and the user is told to use -Force.
+                Mock Resolve-AWSToolsVersion { return [Version]"1.0.3" }
+                Mock Get-PSModulePath { return (Join-Path -Path $HOME -ChildPath "TestPath") }
+                Mock Get-InstalledAWSToolsModule {
+                    return [PSCustomObject]@{ Name = 'AWS.Tools.Installer'; Version = [Version]"1.0.3" }
+                }
+                Mock Resolve-AWSToolsZipSource { }
+                Mock Install-AWSToolsModuleFromZip { }
+                Mock Uninstall-AWSToolsInstaller { }
+
+                # Act
+                Install-AWSToolsInstaller -Version "1.0.3" -Cleanup -Confirm:$false -WarningAction SilentlyContinue -WarningVariable cleanupWarn @script:InformationActionSplat
+
+                # Assert - install and cleanup both skipped; a warning points the user at -Force
+                Should -Not -Invoke Install-AWSToolsModuleFromZip
+                Should -Not -Invoke Uninstall-AWSToolsInstaller
+                ($cleanupWarn -join "`n") | Should -Match 'Cleanup was skipped'
+                ($cleanupWarn -join "`n") | Should -Match '-Force'
+            }
+
             It "Should proceed with installation if Force specified" {
                 # Arrange - Set up mocks for all dependencies
                 Mock Resolve-AWSToolsVersion { return [Version]"1.0.3" }

--- a/tests/Installer/AWS.Tools.Installer.Unit.Public.Install-AWSToolsModule.Tests.ps1
+++ b/tests/Installer/AWS.Tools.Installer.Unit.Public.Install-AWSToolsModule.Tests.ps1
@@ -346,6 +346,67 @@ Describe -Skip:$SkipInstallerTests -Tag "Smoke", "Low", "Medium", "High" "Instal
             Should -Not -Invoke -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip
         }
 
+        It "Should skip cleanup and warn to use -Force when -Cleanup is specified but the target version is already installed" {
+            # Option A: cleanup runs only as part of an installation. When install is skipped
+            # (target already installed), cleanup is skipped too and the user is told to use -Force.
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsVersion { return [Version]"5.0.276" }
+            Mock -ModuleName AWS.Tools.Installer Get-InstalledAWSToolsModule {
+                return @(
+                    [PSCustomObject]@{ Name = 'AWS.Tools.Common'; Version = [Version]"5.0.276" }
+                    [PSCustomObject]@{ Name = 'AWS.Tools.Common'; Version = [Version]"5.0.222" }
+                )
+            }
+            Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip { }
+            Mock -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule { }
+
+            # Act
+            Install-AWSToolsModule -Version "5.0.276" -Cleanup -Confirm:$false -WarningAction SilentlyContinue -WarningVariable cleanupWarn @script:InformationActionSplat
+
+            # Assert - install and cleanup both skipped; a warning points the user at -Force
+            Should -Not -Invoke -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip
+            Should -Not -Invoke -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule
+            ($cleanupWarn -join "`n") | Should -Match 'Cleanup was skipped'
+            ($cleanupWarn -join "`n") | Should -Match '-Force'
+        }
+
+        It "Should skip cleanup and warn for a named install already at the target version with -Cleanup" {
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsVersion { return [Version]"5.0.276" }
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsModuleNames { return @('AWS.Tools.Common', 'AWS.Tools.S3') }
+            Mock -ModuleName AWS.Tools.Installer Get-InstalledAWSToolsModule {
+                return @(
+                    [PSCustomObject]@{ Name = 'AWS.Tools.Common'; Version = [Version]"5.0.276" }
+                    [PSCustomObject]@{ Name = 'AWS.Tools.S3';     Version = [Version]"5.0.276" }
+                    [PSCustomObject]@{ Name = 'AWS.Tools.S3';     Version = [Version]"5.0.222" }
+                )
+            }
+            Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip { }
+            Mock -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule { }
+
+            # Act
+            Install-AWSToolsModule -Name 'AWS.Tools.S3' -Version "5.0.276" -Cleanup -Confirm:$false -WarningAction SilentlyContinue -WarningVariable cleanupWarn @script:InformationActionSplat
+
+            # Assert
+            Should -Not -Invoke -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip
+            Should -Not -Invoke -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule
+            ($cleanupWarn -join "`n") | Should -Match 'Cleanup was skipped'
+        }
+
+        It "Should not warn about cleanup when -Cleanup is not specified and install is skipped" {
+            # Guard: the cleanup-skipped warning must only appear when the user asked for -Cleanup.
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsVersion { return [Version]"5.0.276" }
+            Mock -ModuleName AWS.Tools.Installer Get-InstalledAWSToolsModule {
+                return @([PSCustomObject]@{ Name = 'AWS.Tools.Common'; Version = [Version]"5.0.276" })
+            }
+            Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip { }
+
+            # Act
+            Install-AWSToolsModule -Version "5.0.276" -Confirm:$false -WarningAction SilentlyContinue -WarningVariable cleanupWarn @script:InformationActionSplat
+
+            # Assert
+            Should -Not -Invoke -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip
+            ($cleanupWarn -join "`n") | Should -Not -Match 'Cleanup was skipped'
+        }
+
         It "Should install a named module that is missing even when AWS.Tools.Common is already present at the target version" {
             # Arrange: Common is installed at the target version but the requested
             # service module (AWS.Tools.S3) is not. The skip must NOT fire — Common

--- a/tests/Installer/AWS.Tools.Installer.Unit.Public.Install-AWSToolsModule.Tests.ps1
+++ b/tests/Installer/AWS.Tools.Installer.Unit.Public.Install-AWSToolsModule.Tests.ps1
@@ -407,6 +407,25 @@ Describe -Skip:$SkipInstallerTests -Tag "Smoke", "Low", "Medium", "High" "Instal
             ($cleanupWarn -join "`n") | Should -Not -Match 'Cleanup was skipped'
         }
 
+        It "Should warn that legacy module cleanup was skipped when -CleanUpLegacyModuleScope is specified but installation is skipped" {
+            # Like -Cleanup, -CleanUpLegacyModuleScope is dropped on the skip path; warn and point at -Force.
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsVersion { return [Version]"5.0.276" }
+            Mock -ModuleName AWS.Tools.Installer Get-InstalledAWSToolsModule {
+                return @([PSCustomObject]@{ Name = 'AWS.Tools.Common'; Version = [Version]"5.0.276" })
+            }
+            Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip { }
+            Mock -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule { }
+
+            # Act
+            Install-AWSToolsModule -Version "5.0.276" -CleanUpLegacyModuleScope CurrentUser -Confirm:$false -WarningAction SilentlyContinue -WarningVariable legacyWarn @script:InformationActionSplat
+
+            # Assert - install and legacy cleanup both skipped; a warning points the user at -Force
+            Should -Not -Invoke -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip
+            Should -Not -Invoke -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule
+            ($legacyWarn -join "`n") | Should -Match 'Legacy module cleanup'
+            ($legacyWarn -join "`n") | Should -Match '-Force'
+        }
+
         It "Should install a named module that is missing even when AWS.Tools.Common is already present at the target version" {
             # Arrange: Common is installed at the target version but the requested
             # service module (AWS.Tools.S3) is not. The skip must NOT fire — Common


### PR DESCRIPTION
## Revisions
- **Rev 2:** Addressed review feedback — `-CleanUpLegacyModuleScope` was also silently dropped on the already-installed skip paths. Added a matching warning next to each `-Cleanup` warning in both skip branches, documented it (in-line help + WebHelp), and added a unit test. New dry-run: `a00e4d44-dccd-4dba-a235-9faaaa9f5fad`.
- **Rev 1:** Initial change — warn when `-Cleanup` is skipped because installation was skipped (`Install-AWSToolsModule` and `Install-AWSToolsInstaller`); documentation; version bump `2.0.3` -> `2.0.4`; unit tests. Dry-run: `d465eb49-876f-4fc6-b6db-43d98af94448`.

## Description
When the requested version is already installed, `Install-AWSToolsModule` and `Install-AWSToolsInstaller` skip the install and return before their cleanup step. As a result, a requested `-Cleanup` (or `-CleanUpLegacyModuleScope`) was silently a no-op — older versions were left on disk while the command appeared to succeed.

This change keeps the skip but announces it: when `-Cleanup` (or `-CleanUpLegacyModuleScope`) is specified and installation is skipped, a warning is emitted stating that cleanup was skipped and that `-Force` is required to reinstall and clean up.

Changes:
- `Install-AWSToolsModule` — warn in both the install-all and named-subset skip paths when `-Cleanup` or `-CleanUpLegacyModuleScope` is set.
- `Install-AWSToolsInstaller` — warn in its already-installed skip path when `-Cleanup` is set.
- Documented the behavior on the `-Cleanup` / `-CleanUpLegacyModuleScope` parameters of `Install-AWSToolsModule`, `Update-AWSToolsModule`, and `Install-AWSToolsInstaller` (in-line comment-based help and the static WebHelp pages under `WebHelp/InstallerContent/items/`).
- Bumped `AWS.Tools.Installer` module version `2.0.3` -> `2.0.4`.

The fix keeps cleanup tied to an actual installation: the set of modules to preserve is exactly what was installed from the archive, rather than inferred from local disk state (which can be inaccurate). Emitting a warning and directing the user to `-Force` was chosen over silently changing what cleanup removes.

## Motivation and Context
A customer ran an install without `-Cleanup`, then immediately re-ran with `-Cleanup`, and the older module versions were not removed. Root cause: install was skipped (target already present), and the skip returned before the cleanup step, so `-Cleanup` never ran — with no indication to the user. The fix makes the skipped cleanup visible and tells the user how to force it.

Task: PowerShell-735

## Testing
- Built and staged the module per `buildtools/installer.README.md` (`buildtools/Build-AWSToolsInstaller.ps1`), which compiles `AWS.Tools.Installer.Lib` and stages to `Deployment/AWS.Tools/AWS.Tools.Installer/` (confirmed staged version `2.0.4`).
- Ran the full Installer Pester unit suite: 462 passed, 0 failed, 1 skipped, 5 not-run (skipped/not-run are Windows-only, platform-gated).
- Added unit tests: warn + skip cleanup on the skip path for install-all, named-subset, the installer cmdlet, and `-CleanUpLegacyModuleScope`; and a guard that no warning is emitted when `-Cleanup` is not specified.

### Dry-run
- **Dry-run ID:** a00e4d44-dccd-4dba-a235-9faaaa9f5fad (Rev 2)
- **Status:**
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **Failed bypass reason:** N/A

## Breaking Changes Assessment
No breaking changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
We require a second engineer to validate the PR before merging
- [ ] My code builds in Gamma and passes backward compatibility validation (required)
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## New/existing dependencies impact assessment, if applicable
No new or modified dependencies.

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
