### PR TITLE
Installer 2.0.6: recommend installing all modules and warn when named cleanup excludes AWS.Tools.Common

### DIFF
--- a/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Install-AWSToolsModule.html
+++ b/generator/AWSPSGeneratorLib/HelpMaterials/WebHelp/InstallerContent/items/Install-AWSToolsModule.html
@@ -118,7 +118,10 @@
                         <div class="parameterDescription">Specifies names of the AWS.Tools modules to install. All AWS Tools
                             for PowerShell modules are installed by default. The names can be listed either with or without
                             the "AWS.Tools." prefix (i.e. "AWS.Tools.Common" or simply "Common").<br /><br />
-                            Note: AWS.Tools.Common is automatically included when specific modules are requested, as it is
+                            Installing all modules is the recommended default. It keeps every command ready to use,
+                            reduces the risk of module import conflicts, and extends cleanup to all AWS Tools modules
+                            rather than only those specified.<br /><br />
+                            Note: AWS.Tools.Common is automatically included when specific modules are specified, as it is
                             required for all AWS.Tools modules to function properly.<br /><br />
                             Note: AWS.Tools.Installer cannot be specified here. Use Install-AWSToolsInstaller to manage the
                             installer module.</div>
@@ -176,12 +179,15 @@
                         <div class="parameterDescription">Switch that uninstalls other versions of installed AWS Tools
                             modules after successful installation like when using <code>Uninstall-AWSToolsModule
                             -ExceptVersion ...</code>. Otherwise, by default, other versions remain installed.<br /><br />
-                            When the Name parameter is specified, cleanup only affects the named modules. When Name is not
+                            When the Name parameter is specified, cleanup only affects the specified modules. When Name is not
                             specified, all AWS Tools modules (except installer) are cleaned up.<br /><br />
-                            AWS.Tools.Common is installed automatically as a shared dependency of any named module, but
-                            named cleanup removes older AWS.Tools.Common versions only if AWS.Tools.Common is itself named.
-                            Include AWS.Tools.Common in Name to remove its old versions too; be aware that any other
+                            AWS.Tools.Common is automatically included as a shared dependency when modules are specified, but
+                            cleanup removes other AWS.Tools.Common versions only when AWS.Tools.Common is itself specified.
+                            Include AWS.Tools.Common in Name to remove its other versions too; be aware that any other
                             installed AWS.Tools module pinned to a removed AWS.Tools.Common version will no longer load.<br /><br />
+                            When Name is specified without AWS.Tools.Common and cleanup runs, a warning notes that
+                            AWS.Tools.Common was excluded from cleanup because it was not specified, and recommends
+                            installing all modules or including AWS.Tools.Common in Name.<br /><br />
                             Note: cleanup runs only as part of an installation. If installation is skipped because the
                             requested version is already installed, cleanup is skipped as well and a warning is emitted.
                             Use -Force to reinstall and clean up other installed versions.</div>
@@ -611,7 +617,7 @@
                         <h4>Example 4</h4><pre class="example"><div class="code">Install-AWSToolsModule -WarningAction SilentlyContinue</div><div class="description">This example installs the latest available version of all AWS Tools modules from CloudFront-hosted AWS.Tools.zip. The WarningAction parameter suppresses the production workload warning when you intentionally want the latest version.</div></pre>
                         <h4>Example 5</h4><pre class="example"><div class="code">Install-AWSToolsModule -Cleanup -Confirm:$false</div><div class="description">This example installs all AWS Tools modules from CloudFront-hosted AWS.Tools.zip and removes all non-latest AWS Tools for PowerShell modules without requiring interactive confirmation. Note: Installing without a version constraint may introduce unexpected changes in production workloads.</div></pre>
                         <h4>Example 6</h4><pre class="example"><div class="code">Install-AWSToolsModule -Name Common,EC2,S3</div><div class="description">This example installs the Common, EC2, and S3 modules. AWS.Tools.Common is listed first because every AWS.Tools module depends on it; it is installed automatically even if omitted.</div></pre>
-                        <h4>Example 7</h4><pre class="example"><div class="code">Install-AWSToolsModule -Name Common,EC2,S3 -Cleanup</div><div class="description">This example installs the Common, EC2, and S3 modules and removes all other versions of those three (including older AWS.Tools.Common), leaving other AWS Tools modules untouched. Naming AWS.Tools.Common opts its old versions into cleanup; omit it to preserve them.</div></pre>
+                        <h4>Example 7</h4><pre class="example"><div class="code">Install-AWSToolsModule -Name Common,EC2,S3 -Cleanup</div><div class="description">This example installs the Common, EC2, and S3 modules and removes all other versions of those three, leaving other AWS Tools modules untouched.</div></pre>
                         <h4>Example 8</h4><pre class="example"><div class="code">Install-AWSToolsModule -Timeout 600</div><div class="description">This example installs all AWS Tools modules with a 10-minute download timeout for slower connections.</div></pre>
                         <h4>Example 9</h4><pre class="example"><div class="code">Install-AWSToolsModule -Force</div><div class="description">This example forces reinstallation of AWS Tools modules even if the same version is already installed.</div></pre>
                         <h4>Example 10</h4><pre class="example"><div class="code">Install-AWSToolsModule -Scope AllUsers</div><div class="description">This example installs AWS Tools modules to the system-wide location accessible to all users.</div></pre>

--- a/modules/Installer/AWS.Tools.Installer.psd1
+++ b/modules/Installer/AWS.Tools.Installer.psd1
@@ -10,7 +10,7 @@
     CompatiblePSEditions = @('Core', 'Desktop')
 
     # Version number of this module.
-    ModuleVersion = '2.0.5'
+    ModuleVersion = '2.0.6'
 
     # ID used to uniquely identify this module
     GUID = '450031c1-9177-4fc1-9518-93166b1a926b'

--- a/modules/Installer/Public/Install-AWSToolsModule.ps1
+++ b/modules/Installer/Public/Install-AWSToolsModule.ps1
@@ -16,7 +16,11 @@
     modules are installed by default. The names can be listed either with or without the 
     "AWS.Tools." prefix (i.e. "AWS.Tools.Common" or simply "Common"). 
     
-    Note: AWS.Tools.Common is automatically included when specific modules are requested,
+    Installing all modules is the recommended default. It keeps every command ready to use,
+    reduces the risk of module import conflicts, and extends cleanup to all AWS Tools modules
+    rather than only those specified.
+
+    Note: AWS.Tools.Common is automatically included when specific modules are specified,
     as it is required for all AWS.Tools modules to function properly.
     
     Note: AWS.Tools.Installer cannot be specified here. Use Install-AWSToolsInstaller 
@@ -73,13 +77,17 @@
     
     Otherwise, by default, other versions remain installed.
     
-    When the Name parameter is specified, cleanup only affects the named modules. When Name is not
+    When the Name parameter is specified, cleanup only affects the specified modules. When Name is not
     specified, all AWS Tools modules (except installer) are cleaned up.
 
-    AWS.Tools.Common is installed automatically as a shared dependency of any named module, but
-    named cleanup removes older AWS.Tools.Common versions only if AWS.Tools.Common is itself named.
-    Include AWS.Tools.Common in Name to remove its old versions too; be aware that any other
+    AWS.Tools.Common is automatically included as a shared dependency when modules are specified, but
+    cleanup removes other AWS.Tools.Common versions only when AWS.Tools.Common is itself specified.
+    Include AWS.Tools.Common in Name to remove its other versions too; be aware that any other
     installed AWS.Tools module pinned to a removed AWS.Tools.Common version will no longer load.
+
+    When Name is specified without AWS.Tools.Common and cleanup runs, a warning notes that
+    AWS.Tools.Common was excluded from cleanup because it was not specified, and recommends
+    installing all modules or including AWS.Tools.Common in Name.
 
     Note: cleanup runs only as part of an installation. If installation is skipped because the
     requested version is already installed, cleanup is skipped as well and a warning is emitted.
@@ -188,8 +196,7 @@
     Install-AWSToolsModule -Name Common,EC2,S3 -Cleanup
 
     This example installs the Common, EC2, and S3 modules and removes all other versions of those
-    three (including older AWS.Tools.Common), leaving other AWS Tools modules untouched. Naming
-    AWS.Tools.Common opts its old versions into cleanup; omit it to preserve them.
+    three, leaving other AWS Tools modules untouched.
 
 .Example
     Install-AWSToolsModule -Timeout 600
@@ -786,6 +793,12 @@ To suppress this warning, specify a version constraint. Alternatively, you can s
                     $installedModuleCount = @($installedModules).Count
                     Write-Host "Installed $installedModuleCount AWS Tools modules (version $installedVersionString) to $targetPath"
                     
+                    # On a named (subset) install, recommend the default of installing all modules.
+                    # Skip when invoked under Update-AWSToolsModule — it prints its own guidance.
+                    if ($resolvedNames -and (Get-PSCallStack).Command -notcontains 'Update-AWSToolsModule') {
+                        Write-Host "Installation was limited to the modules specified with -Name. Installing all modules is the recommended default. It keeps every command ready to use, reduces the risk of module import conflicts, and extends cleanup to all AWS Tools modules rather than only those specified."
+                    }
+
                     # Update progress - installation complete, preparing for cleanup
                     Write-Progress -Id 1 -Activity "Install-AWSToolsModule" -Status "Installation complete, cleaning up previous versions..." -PercentComplete 70
                 }
@@ -852,10 +865,20 @@ To suppress this warning, specify a version constraint. Alternatively, you can s
                     
                     # If Name was specified, only clean up those specific modules
                     # This aligns with V1 behavior and avoids surprising destructive cleanup
+                    $commonNotSpecified = $false
                     if ($Name) {
                         $uninstallParams.Name = $Name
                         Write-Verbose ("[$($MyInvocation.MyCommand)] Cleanup constrained to " +
                             "named modules: $($Name -join ', ')")
+
+                        # Named cleanup only removes other versions of the specified modules.
+                        # AWS.Tools.Common is automatically included as a shared dependency but,
+                        # when not specified, is excluded from cleanup. Customers often don't know
+                        # AWS.Tools.Common exists; warn after cleanup runs when it was not specified.
+                        $commonNotSpecified = -not ($Name | Where-Object {
+                            $normalized = if ($_.Contains('.')) { $_ } else { "AWS.Tools.$_" }
+                            $normalized -eq 'AWS.Tools.Common'
+                        })
                     }
                     
                     # Pass WhatIf preference if it's set
@@ -878,6 +901,11 @@ To suppress this warning, specify a version constraint. Alternatively, you can s
                     
                     # Call Uninstall-AWSToolsModule for cleanup
                     Uninstall-AWSToolsModule @uninstallParams | Out-Null
+
+                    # Warn after cleanup completes so the message follows the removal summary.
+                    if ($commonNotSpecified) {
+                        Write-Warning "AWS.Tools.Common, a shared dependency installed automatically, was excluded from cleanup because it was not specified with -Name. To clean up its other versions, install all modules with Install-AWSToolsModule, or include AWS.Tools.Common in -Name."
+                    }
                 }
                 catch {
                     # Cleanup errors are non-terminating - write error but continue

--- a/modules/Installer/Public/Update-AWSToolsModule.ps1
+++ b/modules/Installer/Public/Update-AWSToolsModule.ps1
@@ -251,10 +251,7 @@ function Update-AWSToolsModule {
         
         # Parameter validation for version constraints
         if ($PSCmdlet.ParameterSetName -eq 'ManagedCloudFront' -or $PSCmdlet.ParameterSetName -eq 'Legacy') {
-            # Deprecation warning for restored parameter
-            if ($MaximumVersion) {
-                Write-Warning "The MaximumVersion parameter is deprecated and should no longer be used as it will be removed in the next major version."
-            }
+            # MaximumVersion deprecation warning is emitted by the delegated Install-AWSToolsModule; do not duplicate here.
             
             # Deprecation warnings for ignored legacy parameters
             if ($SkipPublisherCheck) {

--- a/modules/Installer/Public/Update-AWSToolsModule.ps1
+++ b/modules/Installer/Public/Update-AWSToolsModule.ps1
@@ -360,8 +360,9 @@ function Update-AWSToolsModule {
             
             Write-Verbose ("[$($MyInvocation.MyCommand)] Found $($moduleNames.Count) installed AWS.Tools modules to update")
             
-            # Inform users about the number of modules being updated and that Install-AWSToolsModule is needed for new modules
-            Write-Host "Updating $($moduleNames.Count) installed AWS.Tools modules. Note: Use Install-AWSToolsModule to install new AWS modules that may have been released since your last update."
+            # Inform users that Update only touches already-installed modules and that
+            # Install-AWSToolsModule is the recommended way to install and maintain the full set.
+            Write-Host "Updating $($moduleNames.Count) AWS.Tools modules. Update-AWSToolsModule updates installed modules without adding any that are not already installed. Installing all modules with Install-AWSToolsModule is recommended. It keeps every command ready to use, reduces the risk of module import conflicts, and extends cleanup to all AWS Tools modules rather than only those installed."
             
             # Build target description for ShouldProcess
             if ($PSCmdlet.ParameterSetName -eq 'ManagedCloudFront' -or $PSCmdlet.ParameterSetName -eq 'Legacy') {

--- a/tests/Installer/AWS.Tools.Installer.Unit.Public.Install-AWSToolsModule.Tests.ps1
+++ b/tests/Installer/AWS.Tools.Installer.Unit.Public.Install-AWSToolsModule.Tests.ps1
@@ -730,6 +730,173 @@ Describe -Skip:$SkipInstallerTests -Tag "Smoke", "Low", "Medium", "High" "Instal
             Should -Invoke -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule -Times 1
         }
         
+        It "Should write the install-all tip on a named (subset) install" {
+            # A named install nudges toward the default of installing all modules via one host line.
+            Mock -ModuleName AWS.Tools.Installer Test-AWSToolsVersionInstalled { $false }
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsZipSource { Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "AWS.Tools.zip" }
+            Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip {
+                @{
+                    Version = "5.0.286"
+                    Modules = @(
+                        @{ Name = "AWS.Tools.Common"; Version = "5.0.286" }
+                        @{ Name = "AWS.Tools.S3";     Version = "5.0.286" }
+                    )
+                }
+            }
+            Mock -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule { }
+            Mock -ModuleName AWS.Tools.Installer Write-Host { }
+
+            # Act
+            Install-AWSToolsModule -Name 'S3' -Confirm:$false -WarningAction SilentlyContinue @script:InformationActionSplat
+
+            # Assert
+            Should -Invoke -ModuleName AWS.Tools.Installer Write-Host -ParameterFilter {
+                $Object -match 'Installing all modules is the recommended default'
+            } -Times 1
+        }
+
+        It "Should not write the install-all tip on an install-all install" {
+            # No -Name means all modules are already being installed, so the tip would be redundant.
+            Mock -ModuleName AWS.Tools.Installer Test-AWSToolsVersionInstalled { $false }
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsZipSource { Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "AWS.Tools.zip" }
+            Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip {
+                @{
+                    Version = "5.0.286"
+                    Modules = @(
+                        @{ Name = "AWS.Tools.Common"; Version = "5.0.286" }
+                    )
+                }
+            }
+            Mock -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule { }
+            Mock -ModuleName AWS.Tools.Installer Write-Host { }
+
+            # Act
+            Install-AWSToolsModule -Confirm:$false -WarningAction SilentlyContinue @script:InformationActionSplat
+
+            # Assert
+            Should -Not -Invoke -ModuleName AWS.Tools.Installer Write-Host -ParameterFilter {
+                $Object -match 'Installing all modules is the recommended default'
+            }
+        }
+
+        It "Should warn that AWS.Tools.Common was not cleaned up when named cleanup omits it" {
+            # -Name S3 with -Cleanup: cleanup only removes other versions of the named modules, so
+            # the auto-installed AWS.Tools.Common is left in place. Warn since customers may not know.
+            Mock -ModuleName AWS.Tools.Installer Test-AWSToolsVersionInstalled { $false }
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsZipSource { Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "AWS.Tools.zip" }
+            Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip {
+                @{
+                    Version = "5.0.286"
+                    Modules = @(
+                        @{ Name = "AWS.Tools.Common"; Version = "5.0.286" }
+                        @{ Name = "AWS.Tools.S3";     Version = "5.0.286" }
+                    )
+                }
+            }
+            Mock -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule { }
+
+            # Act
+            Install-AWSToolsModule -Name 'S3' -Cleanup -Confirm:$false -WarningAction SilentlyContinue -WarningVariable commonWarn @script:InformationActionSplat
+
+            # Assert
+            Should -Invoke -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule -Times 1
+            ($commonWarn -join "`n") | Should -Match 'was not specified with -Name'
+        }
+
+        It "Should not warn about AWS.Tools.Common when it is among the named modules in the cleanup" {
+            # Naming AWS.Tools.Common puts its other versions in cleanup scope, so no warning.
+            Mock -ModuleName AWS.Tools.Installer Test-AWSToolsVersionInstalled { $false }
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsZipSource { Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "AWS.Tools.zip" }
+            Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip {
+                @{
+                    Version = "5.0.286"
+                    Modules = @(
+                        @{ Name = "AWS.Tools.Common"; Version = "5.0.286" }
+                        @{ Name = "AWS.Tools.S3";     Version = "5.0.286" }
+                    )
+                }
+            }
+            Mock -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule { }
+
+            # Act
+            Install-AWSToolsModule -Name 'Common','S3' -Cleanup -Confirm:$false -WarningAction SilentlyContinue -WarningVariable commonWarn @script:InformationActionSplat
+
+            # Assert
+            ($commonWarn -join "`n") | Should -Not -Match 'was not specified with -Name'
+        }
+
+        It "Should not warn about AWS.Tools.Common for an install-all cleanup" {
+            # No -Name means cleanup covers every module including AWS.Tools.Common; no warning expected.
+            Mock -ModuleName AWS.Tools.Installer Test-AWSToolsVersionInstalled { $false }
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsZipSource { Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "AWS.Tools.zip" }
+            Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip {
+                @{
+                    Version = "5.0.286"
+                    Modules = @(
+                        @{ Name = "AWS.Tools.Common"; Version = "5.0.286" }
+                    )
+                }
+            }
+            Mock -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule { }
+
+            # Act
+            Install-AWSToolsModule -Cleanup -Confirm:$false -WarningAction SilentlyContinue -WarningVariable commonWarn @script:InformationActionSplat
+
+            # Assert
+            ($commonWarn -join "`n") | Should -Not -Match 'was not specified with -Name'
+        }
+
+        It "Should not warn about AWS.Tools.Common when -Name is used without -Cleanup" {
+            # No -Cleanup means no cleanup runs, so there is nothing to warn about leaving behind.
+            Mock -ModuleName AWS.Tools.Installer Test-AWSToolsVersionInstalled { $false }
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsZipSource { Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "AWS.Tools.zip" }
+            Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip {
+                @{
+                    Version = "5.0.286"
+                    Modules = @(
+                        @{ Name = "AWS.Tools.Common"; Version = "5.0.286" }
+                        @{ Name = "AWS.Tools.S3";     Version = "5.0.286" }
+                    )
+                }
+            }
+            Mock -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule { }
+
+            # Act
+            Install-AWSToolsModule -Name 'S3' -Confirm:$false -WarningAction SilentlyContinue -WarningVariable commonWarn @script:InformationActionSplat
+
+            # Assert - cleanup never ran, so no Common warning
+            Should -Not -Invoke -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule
+            ($commonWarn -join "`n") | Should -Not -Match 'was not specified with -Name'
+        }
+
+        It "Should not write the install-all tip when invoked via Update-AWSToolsModule" {
+            # Update-AWSToolsModule delegates to Install-AWSToolsModule with -Name, but the tip is
+            # Update's own concern to suppress. Install detects the Update-AWSToolsModule ancestor
+            # frame via Get-PSCallStack; call the real Update here (Install is not mocked in this
+            # file) so the genuine call stack exercises that detection.
+            Mock -ModuleName AWS.Tools.Installer Test-AWSToolsVersionInstalled { $false }
+            Mock -ModuleName AWS.Tools.Installer Resolve-AWSToolsZipSource { Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "AWS.Tools.zip" }
+            Mock -ModuleName AWS.Tools.Installer Install-AWSToolsModuleFromZip {
+                @{
+                    Version = "5.0.286"
+                    Modules = @(
+                        @{ Name = "AWS.Tools.Common"; Version = "5.0.286" }
+                        @{ Name = "AWS.Tools.EC2";    Version = "5.0.286" }
+                    )
+                }
+            }
+            Mock -ModuleName AWS.Tools.Installer Uninstall-AWSToolsModule { }
+            Mock -ModuleName AWS.Tools.Installer Write-Host { }
+
+            # Act - real Update -> real Install delegation
+            Update-AWSToolsModule -Confirm:$false -WarningAction SilentlyContinue @script:InformationActionSplat
+
+            # Assert
+            Should -Not -Invoke -ModuleName AWS.Tools.Installer Write-Host -ParameterFilter {
+                $Object -match 'Installing all modules is the recommended default'
+            }
+        }
+
         It "Should not accept -SkipCleanup parameter" {
             # Act & Assert
             { Install-AWSToolsModule -SkipCleanup -Confirm:$false -WarningAction SilentlyContinue @script:InformationActionSplat} | Should -Throw

--- a/tests/Installer/AWS.Tools.Installer.Unit.Public.Update-AWSToolsModule.Tests.ps1
+++ b/tests/Installer/AWS.Tools.Installer.Unit.Public.Update-AWSToolsModule.Tests.ps1
@@ -221,7 +221,7 @@ Describe -Skip:$SkipInstallerTests -Tag "Smoke", "Low", "Medium", "High" "Instal
                 $Name -contains "AWS.Tools.S3"
             } -Times 1
             Should -Invoke -ModuleName AWS.Tools.Installer Write-Host -ParameterFilter { 
-                $Object -like "Updating 2 installed AWS.Tools modules*" 
+                $Object -like "Updating 2 AWS.Tools modules*"
             } -Times 1
         }
     }


### PR DESCRIPTION
## Description

Improves `Install-AWSToolsModule` / `Update-AWSToolsModule` console guidance and help around named (subset) installs and cleanup scope:

- **Install-AWSToolsModule** — on a named (subset) install, prints a recommendation to prefer the install-all default: *"Installation was limited to the modules specified with -Name. Installing all modules is the recommended default. It keeps every command ready to use, reduces the risk of module import conflicts, and extends cleanup to all AWS Tools modules rather than only those specified."* Suppressed when invoked under `Update-AWSToolsModule`.
- **Install-AWSToolsModule** — when `-Name` omits `AWS.Tools.Common` and `-Cleanup` runs, warns: *"AWS.Tools.Common, a shared dependency installed automatically, was excluded from cleanup because it was not specified with -Name. To clean up its other versions, install all modules with Install-AWSToolsModule, or include AWS.Tools.Common in -Name."*
- **Update-AWSToolsModule** — clarifies it only updates installed modules (never adds new ones) and recommends `Install-AWSToolsModule` for the full set.
- Updated the `Name` and `Cleanup` comment-based help and the generated WebHelp HTML to match.
- Bumped `AWS.Tools.Installer` 2.0.5 → 2.0.6 (psd1 `ModuleVersion` only).
- **Update-AWSToolsModule** — fixed a duplicate deprecation warning: `-MaximumVersion` printed the deprecation notice twice; the wrapper no longer re-emits it, leaving the delegated `Install-AWSToolsModule` as the sole emitter.

## Motivation and Context

A named install with `-Cleanup` never removes the auto-installed `AWS.Tools.Common`, and customers often don't know `AWS.Tools.Common` exists — so its versions can linger silently. Rather than have named cleanup remove `AWS.Tools.Common` automatically (removing a shared version other installed modules still require would break them), we surface the exclusion and steer customers toward the recommended default of installing all modules, which keeps commands ready to use, reduces import conflicts, and lets cleanup cover all modules. Also clarifies that `Update-AWSToolsModule` only refreshes installed modules.

## Testing

Built `AWS.Tools.Installer.Lib` locally, assembled the module, and ran the `Install-AWSToolsModule` and `Update-AWSToolsModule` Pester unit suites: **92 passing, 0 failing**. New/updated tests cover: the install-all recommendation fires on a named install and is silent on install-all; it is suppressed when invoked via `Update-AWSToolsModule` (caller detection); the Common exclusion warning fires on named `-Cleanup` without Common and is silent when Common is named, on install-all cleanup, and when `-Name` is used without `-Cleanup`.

### Dry-run
- **Dry-run ID:** 48aa43e1-bbdc-4505-bad8-8d31f66eb470
- **Status:**
  - [ ] Pending
  - [x] Completed successfully
  - [ ] Failed
- **Failed bypass reason:**

## Breaking Changes Assessment

Not a breaking change. Adds one informational console line and one warning; parameters, behavior, and on-disk results are unchanged. Both are suppressible (`-InformationAction` / `-WarningAction SilentlyContinue`). No senior/+ reviewer required on breaking-change grounds.

## Screenshots (if appropriate)

N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
We require a second engineer to validate the PR before merging
- [ ] My code builds in Gamma and passes backward compatibility validation (required)
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## New/existing dependencies impact assessment, if applicable

No dependencies added, modified, or removed.

## License
- [x] I confirm that this pull request can be released under the Apache 2 license


